### PR TITLE
docs: add enhancement PRPs for MVP trust loop

### DIFF
--- a/docs/prp/caldav-trust-sync-health-interop-gate.md
+++ b/docs/prp/caldav-trust-sync-health-interop-gate.md
@@ -1,0 +1,609 @@
+# PRP: CalDAV Trust, Sync Health, and Interop Gate
+
+**Type:** Implementation PRP / Product Requirements Prompt  
+**Target Team:** Backend + Web + QA/Interop  
+**Status:** Proposed  
+**Priority:** MVP foundation
+
+---
+
+## 1. Context
+
+Calendar-app's product wedge is a trustworthy self-hosted CalDAV source of truth before AI planning complexity. The app should prove multi-client calendar safety before asking users to connect Todoist or LLM providers.
+
+This PRP strengthens the current CalDAV foundation with sync observability, privacy-safe debug exports, manual interop evidence, and an onboarding gate that requires green CalDAV sync before Todoist/LLM setup.
+
+Current repo assumptions:
+
+- Backend: Go, Chi, emersion/go-webdav, SQLite, goose, slog.
+- Frontend: React, Vite, Tailwind, TanStack Query/Zustand.
+- CalDAV mount: `/dav`.
+- Raw ICS is canonical for CalDAV roundtrip fidelity.
+- ETags are derived from stored ICS bytes.
+- Corrupt stored ICS must fail visibly, not silently return empty data.
+
+---
+
+## 2. Problem statement
+
+Users cannot trust AI planning until they trust that Calendar-app safely syncs their calendar across real CalDAV clients. Self-hosters also need a way to diagnose sync failures without leaking private calendar content into logs or debug bundles.
+
+Calendar-app needs an explicit "CalDAV works before AI" gate: users should prove create/edit/delete from Apple Calendar, Fantastical, DAVx5, or another CalDAV client before Todoist or LLM setup becomes the next step.
+
+---
+
+## 3. Goals
+
+- Prove CalDAV interoperability with at least two primary clients before first AI setup.
+- Add a Sync Health dashboard that exposes recent CalDAV operations without raw event content.
+- Add a redacted debug bundle export for self-hosted support.
+- Document manual interop results in `docs/testing/caldav-interop-results.md`.
+- Add onboarding that guides users to green sync before Todoist/LLM setup.
+- Strengthen data-safety checks around roundtrip fidelity, stale ETags, duplicate UIDs, and corrupt ICS.
+- Make sync failures diagnosable by client fingerprint, operation type, status, and redacted error.
+
+---
+
+## 4. Non-goals
+
+- No real LLM work.
+- No Todoist setup before green CalDAV sync.
+- No full CalDAV scheduling/iTIP.
+- No full RFC 6578 `sync-collection` unless a concrete client interop blocker is discovered.
+- No hosted multi-tenant admin console.
+- No raw ICS/event descriptions in default logs, dashboard rows, or debug bundles.
+- No broad observability platform dependency.
+
+---
+
+## 5. User stories
+
+1. As a self-hosting user, I can see the correct CalDAV URL and app-specific password instructions, connect Apple Calendar or DAVx5, and run a validation event to prove sync works.
+2. As a beta user, I can read a repo doc showing which CalDAV clients pass create/edit/delete testing and known quirks.
+3. As an operator, I can open Sync Health and see recent PROPFIND/REPORT/GET/PUT/DELETE operations with user-agent fingerprints, status codes, ETag outcomes, and durations.
+4. As a privacy-conscious user, I can export a debug bundle that excludes raw ICS, event descriptions, attendee names, and task details by default.
+5. As a user, I get a visible error when stored ICS is corrupt; the server never returns a false successful empty calendar.
+6. As a user, I can see that a stale ETag write was rejected with HTTP 412 and which client caused it.
+
+---
+
+## 6. Functional requirements
+
+### FR1 - CalDAV interop evidence
+
+Create or update `docs/testing/caldav-interop-results.md` with:
+
+- Test date.
+- Calendar-app commit SHA/version.
+- Server OS/runtime.
+- Client name/version.
+- Client platform.
+- Account discovery status.
+- Create event status.
+- Read/list status.
+- Edit event status.
+- Delete event status.
+- ETag conflict behavior.
+- Duplicate UID behavior.
+- Basic recurrence behavior.
+- Timezone event behavior.
+- Known quirks.
+- Screenshots/log snippets if useful, redacted.
+
+Required clients:
+
+- Apple Calendar.
+- Fantastical.
+- DAVx5.
+- Thunderbird if easy; mark as `not tested` or `deferred` if not available.
+
+Pass threshold:
+
+- At least 2 of Apple Calendar, Fantastical, and DAVx5 must pass manual CRUD.
+
+### FR2 - Sync operation logging
+
+Add structured metadata logging for CalDAV requests.
+
+Capture these fields:
+
+- `operation_id`.
+- `timestamp`.
+- `method`: `PROPFIND`, `REPORT`, `GET`, `PUT`, `DELETE`, `PROPPATCH`.
+- `route_template` or redacted path shape.
+- `status_code`.
+- `duration_ms`.
+- `user_id`.
+- `calendar_id`, if known.
+- `event_uid_hash`, if known.
+- `client_user_agent`.
+- `client_fingerprint`.
+- `etag_present`.
+- `etag_match_result`: `matched`, `stale`, `missing`, `not_applicable`.
+- `duplicate_uid_attempt`.
+- `parse_failure`.
+- `corrupt_ics_incident`.
+- `error_code`.
+- `redacted_error_message`.
+- `request_size_bytes`.
+- `response_size_bytes`, optional.
+
+Redaction rules:
+
+- Do not log raw ICS.
+- Do not log event descriptions.
+- Do not log attendee names/emails.
+- Do not log full path segments that may contain user-supplied event names.
+- Hash UID and path identifiers where needed.
+
+### FR3 - Sync Health dashboard
+
+Add a web UI page, likely `/sync-health`, showing:
+
+- Overall status: Healthy / Warning / Critical / Unknown.
+- Last successful CalDAV operation.
+- Last failed CalDAV operation.
+- Last successful sync validation event.
+- Last failed sync validation event.
+- Client fingerprints/user agents seen in last 7 days.
+- Recent 50 CalDAV operations.
+- ETag conflict count, last 24h and all-time.
+- Duplicate UID attempts, last 24h and all-time.
+- Parse failures, last 24h and all-time.
+- Corrupt ICS incidents, last 24h and all-time.
+- Median and p95 operation duration.
+- Links to export debug bundle, interop results, and client setup instructions.
+
+Recent operation table columns:
+
+- Time.
+- Client.
+- Method.
+- Resource type: calendar/event/principal/unknown.
+- Status.
+- ETag result.
+- Duration.
+- Redacted error.
+
+### FR4 - Sync Health API
+
+Add REST endpoints:
+
+```http
+GET  /api/v1/sync-health
+GET  /api/v1/sync-health/operations?limit=50
+GET  /api/v1/sync-health/clients
+POST /api/v1/sync-health/validation-event/start
+POST /api/v1/sync-health/validation-event/verify
+GET  /api/v1/debug-bundle
+```
+
+Example `GET /api/v1/sync-health` response:
+
+```json
+{
+  "status": "healthy",
+  "last_success_at": "2026-04-25T14:05:02Z",
+  "last_failure_at": null,
+  "operation_counts_24h": {
+    "total": 128,
+    "success": 126,
+    "failure": 2,
+    "etag_conflicts": 1,
+    "duplicate_uid_attempts": 0,
+    "parse_failures": 0,
+    "corrupt_ics_incidents": 0
+  },
+  "latency_ms": {
+    "median": 22,
+    "p95": 180
+  },
+  "clients": [
+    {
+      "fingerprint": "apple-calendar-macos-redacted",
+      "display_name": "Apple Calendar",
+      "last_seen_at": "2026-04-25T14:00:00Z",
+      "operation_count_24h": 44
+    }
+  ]
+}
+```
+
+### FR5 - Debug bundle export
+
+Add a debug bundle export as `.zip` or `.tar.gz`.
+
+Default contents:
+
+- `manifest.json` with Calendar-app version/commit, runtime summary, config summary with secrets redacted, data directory presence, database migration version.
+- `sync_health_summary.json`.
+- `recent_caldav_operations.json`.
+- `client_fingerprints.json`.
+- `error_traces.log`.
+- `schema_summary.txt`.
+- `interop_checklist_template.md`.
+
+Default exclusions:
+
+- Raw ICS.
+- Event descriptions.
+- Attendees.
+- Task content.
+- LLM API keys.
+- Todoist tokens.
+- Passwords.
+- Authorization headers.
+- Session cookies.
+
+Optional explicit toggle:
+
+```http
+GET /api/v1/debug-bundle?include_raw_event_data=true
+```
+
+Rules:
+
+- UI must display a warning before raw event data inclusion.
+- Raw data export must require explicit user action.
+- Include manifest flag: `"raw_event_data_included": true`.
+
+### FR6 - Onboarding gate
+
+Add onboarding sequence:
+
+1. Show server status.
+2. Show CalDAV URL: `https://<host>/dav/`, principal URL if needed, and calendar home URL pattern if needed.
+3. Generate or display app-specific CalDAV password.
+4. Show client setup recipes for Apple Calendar, Fantastical, DAVx5, and optionally Thunderbird.
+5. Start validation event flow:
+   - User creates event from external client.
+   - User edits event title/time from external client.
+   - User deletes event from external client.
+6. Calendar-app detects each step by operation log and repository state.
+7. Mark `Green sync` only when create/edit/delete pass.
+8. Unlock Todoist setup.
+9. Unlock LLM setup.
+
+Validation event:
+
+- Suggested event title: `Calendar-app Sync Test`.
+- Use generated UID prefix or marker to detect safely.
+- Delete the test event after validation, or require external client delete step.
+
+Failure states must include explanation, last observed operation, suggested next step, debug bundle link, and client-specific guidance.
+
+### FR7 - Data safety checks
+
+Automated and runtime behavior must guarantee:
+
+- PUT -> GET roundtrip preserves event data.
+- ETag conflict handling returns HTTP 412 on stale writes.
+- Duplicate UID attempts do not create duplicate events.
+- Corrupt stored ICS returns visible 500/diagnostic error, not empty success.
+- Parse failures increment metrics and appear in Sync Health.
+- PUT/DELETE mutate event and calendar sync token atomically.
+- UID uniqueness remains enforced at DB level.
+- Any parse or storage failure is logged with redacted metadata.
+
+---
+
+## 7. Non-functional requirements
+
+- Privacy: no raw event content in logs or default debug bundles.
+- Reliability: sync health instrumentation must not break CalDAV request handling.
+- Performance: logging overhead should add less than 10ms p95 for typical CalDAV operations.
+- Durability: operation logs should survive restarts with bounded retention.
+- Retention: default keep recent operation metadata for 7 days or last 1,000 operations, whichever is smaller.
+- Accessibility: Sync Health and onboarding UI must meet WCAG 2.1 AA.
+- Local-first: diagnostics are generated locally by the self-hosted instance.
+- Graceful degradation: if metrics persistence fails, CalDAV operations continue and log a redacted warning.
+
+---
+
+## 8. Technical approach
+
+### Backend
+
+Add an instrumentation layer around the CalDAV handler/middleware:
+
+- Generate `operation_id` at request start.
+- Capture method, path shape, user agent, start time, response status, duration.
+- Extract safe authenticated user/calendar/event identifiers where possible.
+- Capture ETag/precondition outcomes from backend errors where possible.
+- Persist operation metadata to SQLite.
+
+Add explicit domain errors:
+
+- `ErrDuplicateUID`.
+- `ErrCorruptICS`.
+- `ErrParseFailed`.
+- `ErrStaleETag`.
+- `ErrInteropValidationFailed`.
+
+Suggested service interfaces:
+
+```go
+type SyncHealthService interface {
+    RecordOperation(ctx context.Context, op CalDAVOperation) error
+    Summary(ctx context.Context) (*SyncHealthSummary, error)
+    RecentOperations(ctx context.Context, limit int) ([]CalDAVOperation, error)
+    Clients(ctx context.Context) ([]ClientFingerprint, error)
+    StartValidationEvent(ctx context.Context, userID int64) (*ValidationSession, error)
+    VerifyValidationEvent(ctx context.Context, sessionID string) (*ValidationResult, error)
+}
+
+type DebugBundleService interface {
+    Build(ctx context.Context, opts DebugBundleOptions) (*DebugBundle, error)
+}
+```
+
+### Frontend
+
+Add routes/pages:
+
+- `/onboarding/caldav`.
+- `/sync-health`.
+- `/settings/debug`.
+
+Use TanStack Query for:
+
+- Sync health summary.
+- Recent operations.
+- Debug bundle download.
+- Validation session state.
+
+---
+
+## 9. Files likely to change
+
+Backend:
+
+```text
+server/internal/caldav/handler.go
+server/internal/caldav/backend.go
+server/internal/caldav/auth.go
+server/internal/caldav/proppatch.go
+server/internal/caldav/sync.go
+server/internal/caldav/observability.go
+server/internal/caldav/client_fingerprint.go
+server/internal/api/sync_health.go
+server/internal/api/debug_bundle.go
+server/internal/data/sqlite_caldav_operation_repo.go
+server/internal/data/sqlite_validation_repo.go
+server/internal/domain/sync_health.go
+server/internal/domain/errors.go
+server/internal/services/sync_health.go
+server/internal/services/debug_bundle.go
+server/migrations/00002_sync_health.sql
+server/cmd/calendarapp/main.go
+```
+
+Frontend:
+
+```text
+web/src/pages/OnboardingCalDAVPage.tsx
+web/src/pages/SyncHealthPage.tsx
+web/src/pages/DebugBundlePage.tsx
+web/src/components/sync/SyncStatusBadge.tsx
+web/src/components/sync/OperationTable.tsx
+web/src/components/sync/ClientList.tsx
+web/src/components/onboarding/CalDAVSetupRecipe.tsx
+web/src/lib/api.ts
+web/src/lib/types.ts
+web/src/App.tsx
+```
+
+Docs/tests:
+
+```text
+docs/testing/caldav-interop-results.md
+docs/setup/caldav-clients.md
+server/internal/caldav/*_test.go
+server/internal/api/sync_health_test.go
+server/internal/services/debug_bundle_test.go
+```
+
+---
+
+## 10. API changes
+
+```http
+GET  /api/v1/sync-health
+GET  /api/v1/sync-health/operations?limit=50
+GET  /api/v1/sync-health/clients
+POST /api/v1/sync-health/validation-event/start
+POST /api/v1/sync-health/validation-event/verify
+GET  /api/v1/debug-bundle
+GET  /api/v1/debug-bundle?include_raw_event_data=true
+```
+
+---
+
+## 11. Database/schema changes
+
+Create migration `server/migrations/00002_sync_health.sql`.
+
+```sql
+CREATE TABLE caldav_operations (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  operation_id TEXT NOT NULL UNIQUE,
+  user_id INTEGER,
+  calendar_id INTEGER,
+  event_uid_hash TEXT,
+  method TEXT NOT NULL,
+  route_shape TEXT NOT NULL,
+  status_code INTEGER NOT NULL,
+  duration_ms INTEGER NOT NULL,
+  client_user_agent TEXT,
+  client_fingerprint TEXT,
+  etag_present BOOLEAN DEFAULT 0,
+  etag_match_result TEXT,
+  duplicate_uid_attempt BOOLEAN DEFAULT 0,
+  parse_failure BOOLEAN DEFAULT 0,
+  corrupt_ics_incident BOOLEAN DEFAULT 0,
+  error_code TEXT,
+  redacted_error_message TEXT,
+  request_size_bytes INTEGER,
+  response_size_bytes INTEGER,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL,
+  FOREIGN KEY (calendar_id) REFERENCES calendars(id) ON DELETE SET NULL
+);
+
+CREATE INDEX idx_caldav_operations_created_at ON caldav_operations(created_at);
+CREATE INDEX idx_caldav_operations_user_id ON caldav_operations(user_id);
+CREATE INDEX idx_caldav_operations_client_fingerprint ON caldav_operations(client_fingerprint);
+CREATE INDEX idx_caldav_operations_status_code ON caldav_operations(status_code);
+
+CREATE TABLE sync_validation_sessions (
+  id TEXT PRIMARY KEY,
+  user_id INTEGER NOT NULL,
+  expected_uid_prefix TEXT NOT NULL,
+  status TEXT NOT NULL,
+  create_observed_at DATETIME,
+  edit_observed_at DATETIME,
+  delete_observed_at DATETIME,
+  failure_code TEXT,
+  failure_message TEXT,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  expires_at DATETIME NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+```
+
+---
+
+## 12. UX changes
+
+### Onboarding checklist
+
+```text
+CalDAV setup
+
+[ ] Server is running
+[ ] App-specific password created
+[ ] Connect one calendar client
+[ ] Create validation event
+[ ] Edit validation event
+[ ] Delete validation event
+
+Todoist and LLM setup unlock after Green Sync.
+```
+
+### Sync Health summary
+
+```text
+Sync: Healthy
+Last successful sync: 2 minutes ago
+Clients seen: Apple Calendar, DAVx5
+ETag conflicts today: 1
+Parse failures today: 0
+Corrupt ICS incidents: 0
+p95 operation duration: 180ms
+```
+
+---
+
+## 13. Test plan
+
+Automated tests:
+
+- `TestCalDAVOperationLoggedOnPUT`.
+- `TestCalDAVOperationLoggedOnGET`.
+- `TestCalDAVOperationLogsNoRawICS`.
+- `TestSyncHealthSummaryCountsETagConflicts`.
+- `TestDebugBundleExcludesRawICSByDefault`.
+- `TestDebugBundleExcludesEventDescriptionsByDefault`.
+- `TestDebugBundleIncludesRawDataOnlyWithExplicitOption`.
+- `TestValidationEventCreateEditDeleteFlow`.
+- `TestStaleETagReturns412AndIncrementsConflictCount`.
+- `TestDuplicateUIDRejectedAndLogged`.
+- `TestCorruptStoredICSReturns500AndLogged`.
+- `TestPUTGETRoundtripPreservesICS`.
+
+Manual tests:
+
+- Apple Calendar create/edit/delete.
+- Fantastical create/edit/delete.
+- DAVx5 create/edit/delete.
+- Thunderbird optional create/edit/delete.
+- Simultaneous edit from two clients.
+- Debug bundle privacy review.
+
+---
+
+## 14. Manual validation steps
+
+1. Run `cd server && go test ./...`.
+2. Start the server.
+3. Open onboarding.
+4. Generate app-specific password.
+5. Add Apple Calendar account using `/dav/`.
+6. Create `Calendar-app Sync Test`.
+7. Confirm UI detects create.
+8. Edit test event.
+9. Confirm UI detects edit.
+10. Delete test event.
+11. Confirm UI shows green sync.
+12. Open Sync Health.
+13. Confirm recent operations show methods/status/duration/client without raw content.
+14. Export default debug bundle.
+15. Inspect bundle for raw ICS/event descriptions; none should exist.
+16. Repeat with DAVx5 or Fantastical.
+17. Update `docs/testing/caldav-interop-results.md`.
+
+---
+
+## 15. Acceptance criteria
+
+- `go test ./...` passes.
+- PUT -> GET roundtrip preserves event data.
+- Stale ETag writes return HTTP 412.
+- At least 2 of Apple Calendar, Fantastical, and DAVx5 pass manual CRUD testing.
+- Sync Health page shows latest client operations without leaking raw event content.
+- Debug bundle exports redacted diagnostics.
+- Debug bundle raw event data requires explicit user opt-in.
+- Onboarding can verify create/edit/delete from at least one external CalDAV client.
+- Todoist/LLM setup is visually and functionally gated behind green sync.
+- `docs/testing/caldav-interop-results.md` exists and is updated.
+- Corrupt stored ICS fails visibly and increments corrupt incident count.
+- Duplicate UID attempts are rejected and visible in Sync Health.
+
+---
+
+## 16. Risks and mitigations
+
+| Risk | Impact | Mitigation |
+|---|---:|---|
+| Logs leak private data | Critical | Redaction tests, bundle inspection tests, no raw ICS by default |
+| Instrumentation breaks CalDAV | High | Middleware-only logging, fail-open if logging persistence fails |
+| Client-specific quirks consume scope | Medium | Document quirks; require 2 of 3 primary clients, Thunderbird optional |
+| Validation event false negatives | Medium | Use operation log + repository state; provide manual retry |
+| Debug bundle grows large | Low | Retention limits, compressed bundle, metadata-only default |
+| Sync Health creates anxiety | Low | Explain statuses and next actions clearly |
+
+---
+
+## 17. Open questions
+
+- Should app-specific CalDAV passwords be implemented in this PRP or can dev env Basic Auth remain for the first version?
+- What retention default is best: 7 days, last 1,000 operations, or both?
+- Should Sync Health be visible before login for local single-user setups, or authenticated only?
+- Should client fingerprinting normalize known clients into friendly names?
+- Should validation event run against the default calendar only?
+
+---
+
+## 18. Suggested GitHub issue breakdown
+
+1. `feat(server): add CalDAV operation metadata logging`
+2. `feat(server): add sync health repository and summary service`
+3. `feat(api): expose sync health endpoints`
+4. `feat(server): add redacted debug bundle export`
+5. `feat(web): add Sync Health dashboard`
+6. `feat(web): add CalDAV onboarding gate`
+7. `test(caldav): add validation-event flow tests`
+8. `test(caldav): add stale ETag, duplicate UID, corrupt ICS diagnostics tests`
+9. `docs(testing): add CalDAV interop results matrix`
+10. `docs(setup): add Apple Calendar, Fantastical, DAVx5 setup recipes`

--- a/docs/prp/caldav-trust-sync-health-interop-gate.md
+++ b/docs/prp/caldav-trust-sync-health-interop-gate.md
@@ -21,6 +21,7 @@ Current repo assumptions:
 - Raw ICS is canonical for CalDAV roundtrip fidelity.
 - ETags are derived from stored ICS bytes.
 - Corrupt stored ICS must fail visibly, not silently return empty data.
+- MVP CalDAV auth uses the existing HTTP Basic Auth / environment credential path.
 
 ---
 
@@ -41,6 +42,7 @@ Calendar-app needs an explicit "CalDAV works before AI" gate: users should prove
 - Add onboarding that guides users to green sync before Todoist/LLM setup.
 - Strengthen data-safety checks around roundtrip fidelity, stale ETags, duplicate UIDs, and corrupt ICS.
 - Make sync failures diagnosable by client fingerprint, operation type, status, and redacted error.
+- Keep MVP auth simple by reusing the existing Basic Auth/env credential path.
 
 ---
 
@@ -53,21 +55,41 @@ Calendar-app needs an explicit "CalDAV works before AI" gate: users should prove
 - No hosted multi-tenant admin console.
 - No raw ICS/event descriptions in default logs, dashboard rows, or debug bundles.
 - No broad observability platform dependency.
+- No new credential model in this PRP.
+- No app-specific password generation, password rotation, or per-client credentials in MVP.
 
 ---
 
-## 5. User stories
+## 5. MVP Auth Decision
 
-1. As a self-hosting user, I can see the correct CalDAV URL and app-specific password instructions, connect Apple Calendar or DAVx5, and run a validation event to prove sync works.
+For MVP, Calendar-app will reuse the existing HTTP Basic Auth / environment credential path, currently configured through `CALENDARAPP_USER` and `CALENDARAPP_PASS`.
+
+The onboarding UI should display:
+
+- configured CalDAV username instructions,
+- configured password instructions,
+- server URL,
+- principal/calendar URL guidance where needed,
+- client setup recipes for supported CalDAV clients.
+
+The onboarding UI should not create, rotate, or manage per-client app-specific passwords in this PRP.
+
+App-specific CalDAV passwords are a post-MVP enhancement and should be tracked separately. A future credential PRP should define schema, generation endpoint, rotation/revocation UX, per-client labels, and tests.
+
+---
+
+## 6. User stories
+
+1. As a self-hosting user, I can see the correct CalDAV URL and Basic Auth credential instructions, connect Apple Calendar or DAVx5, and run a validation event to prove sync works.
 2. As a beta user, I can read a repo doc showing which CalDAV clients pass create/edit/delete testing and known quirks.
-3. As an operator, I can open Sync Health and see recent PROPFIND/REPORT/GET/PUT/DELETE operations with user-agent fingerprints, status codes, ETag outcomes, and durations.
+3. As an operator, I can open Sync Health and see recent PROPFIND/REPORT/GET/PUT/DELETE operations with client fingerprints, status codes, ETag outcomes, and durations.
 4. As a privacy-conscious user, I can export a debug bundle that excludes raw ICS, event descriptions, attendee names, and task details by default.
 5. As a user, I get a visible error when stored ICS is corrupt; the server never returns a false successful empty calendar.
 6. As a user, I can see that a stale ETag write was rejected with HTTP 412 and which client caused it.
 
 ---
 
-## 6. Functional requirements
+## 7. Functional requirements
 
 ### FR1 - CalDAV interop evidence
 
@@ -99,7 +121,9 @@ Required clients:
 
 Pass threshold:
 
-- At least 2 of Apple Calendar, Fantastical, and DAVx5 must pass manual CRUD.
+- Apple Calendar, Fantastical, and DAVx5 must all be represented in `docs/testing/caldav-interop-results.md`.
+- At least 2 of Apple Calendar, Fantastical, and DAVx5 must pass manual CRUD for MVP.
+- Non-passing or not-yet-tested clients must be documented with status, reason, and follow-up issue.
 
 ### FR2 - Sync operation logging
 
@@ -135,6 +159,17 @@ Redaction rules:
 - Do not log attendee names/emails.
 - Do not log full path segments that may contain user-supplied event names.
 - Hash UID and path identifiers where needed.
+- Raw `client_user_agent` may be stored locally for self-hosted diagnostics, but exported debug bundles should normalize or redact unusually identifying user-agent values by default.
+
+Debug bundles may include normalized client fingerprints such as:
+
+- `apple-calendar`.
+- `fantastical`.
+- `davx5`.
+- `thunderbird`.
+- `unknown-caldav-client`.
+
+Raw user-agent export requires explicit user opt-in.
 
 ### FR3 - Sync Health dashboard
 
@@ -165,7 +200,50 @@ Recent operation table columns:
 - Duration.
 - Redacted error.
 
-### FR4 - Sync Health API
+### FR4 - Sync Health status rules
+
+Status computation must be deterministic. Exact thresholds should be implementation-configurable, but MVP defaults must be documented and tested.
+
+`Healthy`
+
+- Green-sync validation completed successfully.
+- Last validation event create/edit/delete passed.
+- No CalDAV write failures in the recent operation window.
+- No corrupt ICS incidents in the recent operation window.
+- No unresolved duplicate UID incidents.
+- ETag conflicts, if present, are expected HTTP 412 conflicts and below warning threshold.
+
+`Warning`
+
+- Green-sync validation completed previously but recent operations show recoverable failures.
+- Recent ETag conflicts exceed threshold.
+- A supported client has recent sync failures but data integrity is not known to be compromised.
+- Validation is stale and should be rerun.
+
+`Critical`
+
+- Corrupt stored ICS detected.
+- Duplicate UID incident unresolved.
+- PUT/GET roundtrip validation failed.
+- Green-sync validation failed.
+- Calendar write path is failing.
+- Data integrity may be at risk.
+
+`Unknown`
+
+- Green-sync validation has not been completed.
+- No recent client operation data exists.
+- Server cannot determine sync health.
+
+MVP default thresholds:
+
+- Recent operation window: latest 50 operations or last 24 hours, whichever has data.
+- Warning threshold for expected ETag conflicts: more than 5 stale-write conflicts in the recent operation window.
+- Validation stale threshold: green-sync validation older than 14 days.
+- Any corrupt ICS incident in the recent operation window is `Critical` until resolved or explicitly acknowledged by future tooling.
+- Any unresolved duplicate UID incident is `Critical` until resolved.
+
+### FR5 - Sync Health API
 
 Add REST endpoints:
 
@@ -185,6 +263,8 @@ Example `GET /api/v1/sync-health` response:
   "status": "healthy",
   "last_success_at": "2026-04-25T14:05:02Z",
   "last_failure_at": null,
+  "green_sync_completed": true,
+  "green_sync_completed_at": "2026-04-25T13:50:00Z",
   "operation_counts_24h": {
     "total": 128,
     "success": 126,
@@ -200,7 +280,7 @@ Example `GET /api/v1/sync-health` response:
   },
   "clients": [
     {
-      "fingerprint": "apple-calendar-macos-redacted",
+      "fingerprint": "apple-calendar",
       "display_name": "Apple Calendar",
       "last_seen_at": "2026-04-25T14:00:00Z",
       "operation_count_24h": 44
@@ -209,9 +289,13 @@ Example `GET /api/v1/sync-health` response:
 }
 ```
 
-### FR5 - Debug bundle export
+### FR6 - Debug bundle export
 
 Add a debug bundle export as `.zip` or `.tar.gz`.
+
+`/api/v1/debug-bundle` must require authenticated local admin/session access. It must never be publicly accessible.
+
+Debug bundle export should be auditable in local logs with timestamp and authenticated user/session identifier, but without raw event content.
 
 Default contents:
 
@@ -234,6 +318,7 @@ Default exclusions:
 - Passwords.
 - Authorization headers.
 - Session cookies.
+- Raw user-agent strings when they look unusually identifying.
 
 Optional explicit toggle:
 
@@ -246,14 +331,15 @@ Rules:
 - UI must display a warning before raw event data inclusion.
 - Raw data export must require explicit user action.
 - Include manifest flag: `"raw_event_data_included": true`.
+- Raw user-agent export requires explicit user opt-in, separate from normalized fingerprint export.
 
-### FR6 - Onboarding gate
+### FR7 - Onboarding gate
 
 Add onboarding sequence:
 
 1. Show server status.
 2. Show CalDAV URL: `https://<host>/dav/`, principal URL if needed, and calendar home URL pattern if needed.
-3. Generate or display app-specific CalDAV password.
+3. Display configured CalDAV username/password instructions from the existing Basic Auth/env credential path.
 4. Show client setup recipes for Apple Calendar, Fantastical, DAVx5, and optionally Thunderbird.
 5. Start validation event flow:
    - User creates event from external client.
@@ -264,6 +350,14 @@ Add onboarding sequence:
 8. Unlock Todoist setup.
 9. Unlock LLM setup.
 
+MVP credential scope:
+
+- Do not create a new credential model.
+- Do not add password-generation endpoints.
+- Do not add password-rotation UI.
+- Do not add per-client credentials.
+- App-specific CalDAV passwords are post-MVP.
+
 Validation event:
 
 - Suggested event title: `Calendar-app Sync Test`.
@@ -272,7 +366,7 @@ Validation event:
 
 Failure states must include explanation, last observed operation, suggested next step, debug bundle link, and client-specific guidance.
 
-### FR7 - Data safety checks
+### FR8 - Data safety checks
 
 Automated and runtime behavior must guarantee:
 
@@ -285,32 +379,47 @@ Automated and runtime behavior must guarantee:
 - UID uniqueness remains enforced at DB level.
 - Any parse or storage failure is logged with redacted metadata.
 
+### FR9 - Retention cleanup
+
+Sync operation logs must have a bounded retention policy.
+
+MVP default:
+
+- retain the latest 1,000 operations, or
+- retain 14 days of operations,
+- whichever limit is reached first.
+
+A cleanup job or write-time pruning must enforce this retention.
+
 ---
 
-## 7. Non-functional requirements
+## 8. Non-functional requirements
 
 - Privacy: no raw event content in logs or default debug bundles.
 - Reliability: sync health instrumentation must not break CalDAV request handling.
 - Performance: logging overhead should add less than 10ms p95 for typical CalDAV operations.
 - Durability: operation logs should survive restarts with bounded retention.
-- Retention: default keep recent operation metadata for 7 days or last 1,000 operations, whichever is smaller.
+- Retention: latest 1,000 operations or 14 days, whichever limit is reached first.
 - Accessibility: Sync Health and onboarding UI must meet WCAG 2.1 AA.
 - Local-first: diagnostics are generated locally by the self-hosted instance.
+- Auth: debug bundle access requires authenticated local admin/session access.
 - Graceful degradation: if metrics persistence fails, CalDAV operations continue and log a redacted warning.
 
 ---
 
-## 8. Technical approach
+## 9. Technical approach
 
 ### Backend
 
 Add an instrumentation layer around the CalDAV handler/middleware:
 
 - Generate `operation_id` at request start.
-- Capture method, path shape, user agent, start time, response status, duration.
+- Capture method, path shape, normalized client fingerprint, start time, response status, duration.
+- Store raw user agent locally only when useful for self-hosted diagnostics.
 - Extract safe authenticated user/calendar/event identifiers where possible.
 - Capture ETag/precondition outcomes from backend errors where possible.
 - Persist operation metadata to SQLite.
+- Enforce retention by cleanup job or write-time pruning.
 
 Add explicit domain errors:
 
@@ -330,10 +439,11 @@ type SyncHealthService interface {
     Clients(ctx context.Context) ([]ClientFingerprint, error)
     StartValidationEvent(ctx context.Context, userID int64) (*ValidationSession, error)
     VerifyValidationEvent(ctx context.Context, sessionID string) (*ValidationResult, error)
+    PruneOperations(ctx context.Context, policy RetentionPolicy) error
 }
 
 type DebugBundleService interface {
-    Build(ctx context.Context, opts DebugBundleOptions) (*DebugBundle, error)
+    Build(ctx context.Context, userID int64, opts DebugBundleOptions) (*DebugBundle, error)
 }
 ```
 
@@ -354,7 +464,7 @@ Use TanStack Query for:
 
 ---
 
-## 9. Files likely to change
+## 10. Files likely to change
 
 Backend:
 
@@ -405,7 +515,7 @@ server/internal/services/debug_bundle_test.go
 
 ---
 
-## 10. API changes
+## 11. API changes
 
 ```http
 GET  /api/v1/sync-health
@@ -417,9 +527,11 @@ GET  /api/v1/debug-bundle
 GET  /api/v1/debug-bundle?include_raw_event_data=true
 ```
 
+No credential-generation API is included in MVP.
+
 ---
 
-## 11. Database/schema changes
+## 12. Database/schema changes
 
 Create migration `server/migrations/00002_sync_health.sql`.
 
@@ -472,9 +584,11 @@ CREATE TABLE sync_validation_sessions (
 );
 ```
 
+No credential schema changes are required in this PRP.
+
 ---
 
-## 12. UX changes
+## 13. UX changes
 
 ### Onboarding checklist
 
@@ -482,7 +596,8 @@ CREATE TABLE sync_validation_sessions (
 CalDAV setup
 
 [ ] Server is running
-[ ] App-specific password created
+[ ] CalDAV URL displayed
+[ ] Basic Auth username/password instructions displayed
 [ ] Connect one calendar client
 [ ] Create validation event
 [ ] Edit validation event
@@ -505,7 +620,7 @@ p95 operation duration: 180ms
 
 ---
 
-## 13. Test plan
+## 14. Test plan
 
 Automated tests:
 
@@ -513,14 +628,21 @@ Automated tests:
 - `TestCalDAVOperationLoggedOnGET`.
 - `TestCalDAVOperationLogsNoRawICS`.
 - `TestSyncHealthSummaryCountsETagConflicts`.
+- `TestSyncHealthStatusHealthy`.
+- `TestSyncHealthStatusWarning`.
+- `TestSyncHealthStatusCritical`.
+- `TestSyncHealthStatusUnknown`.
+- `TestDebugBundleRequiresAuthenticatedAccess`.
 - `TestDebugBundleExcludesRawICSByDefault`.
 - `TestDebugBundleExcludesEventDescriptionsByDefault`.
+- `TestDebugBundleNormalizesClientUserAgentsByDefault`.
 - `TestDebugBundleIncludesRawDataOnlyWithExplicitOption`.
 - `TestValidationEventCreateEditDeleteFlow`.
 - `TestStaleETagReturns412AndIncrementsConflictCount`.
 - `TestDuplicateUIDRejectedAndLogged`.
 - `TestCorruptStoredICSReturns500AndLogged`.
 - `TestPUTGETRoundtripPreservesICS`.
+- `TestOperationRetentionPrunesOldRows`.
 
 Manual tests:
 
@@ -533,13 +655,13 @@ Manual tests:
 
 ---
 
-## 14. Manual validation steps
+## 15. Manual validation steps
 
 1. Run `cd server && go test ./...`.
-2. Start the server.
+2. Start the server with `CALENDARAPP_USER` and `CALENDARAPP_PASS` configured.
 3. Open onboarding.
-4. Generate app-specific password.
-5. Add Apple Calendar account using `/dav/`.
+4. Confirm the CalDAV URL and Basic Auth credential instructions are displayed.
+5. Add Apple Calendar account using `/dav/` and the configured Basic Auth credentials.
 6. Create `Calendar-app Sync Test`.
 7. Confirm UI detects create.
 8. Edit test event.
@@ -548,62 +670,71 @@ Manual tests:
 11. Confirm UI shows green sync.
 12. Open Sync Health.
 13. Confirm recent operations show methods/status/duration/client without raw content.
-14. Export default debug bundle.
-15. Inspect bundle for raw ICS/event descriptions; none should exist.
+14. Export default debug bundle while authenticated.
+15. Inspect bundle for raw ICS/event descriptions/raw identifying UA; none should exist by default.
 16. Repeat with DAVx5 or Fantastical.
 17. Update `docs/testing/caldav-interop-results.md`.
 
 ---
 
-## 15. Acceptance criteria
+## 16. Acceptance criteria
 
 - `go test ./...` passes.
 - PUT -> GET roundtrip preserves event data.
 - Stale ETag writes return HTTP 412.
+- Apple Calendar, Fantastical, and DAVx5 are all represented in `docs/testing/caldav-interop-results.md`.
 - At least 2 of Apple Calendar, Fantastical, and DAVx5 pass manual CRUD testing.
 - Sync Health page shows latest client operations without leaking raw event content.
-- Debug bundle exports redacted diagnostics.
+- Sync Health statuses use deterministic Healthy / Warning / Critical / Unknown rules.
+- Debug bundle endpoint requires authenticated local admin/session access.
+- Debug bundle exports redacted diagnostics by default.
 - Debug bundle raw event data requires explicit user opt-in.
+- Raw user-agent export requires explicit user opt-in.
 - Onboarding can verify create/edit/delete from at least one external CalDAV client.
+- Onboarding uses existing Basic Auth/env credentials and does not generate app-specific passwords.
 - Todoist/LLM setup is visually and functionally gated behind green sync.
 - `docs/testing/caldav-interop-results.md` exists and is updated.
 - Corrupt stored ICS fails visibly and increments corrupt incident count.
 - Duplicate UID attempts are rejected and visible in Sync Health.
+- Operation log retention is enforced by cleanup job or write-time pruning.
 
 ---
 
-## 16. Risks and mitigations
+## 17. Risks and mitigations
 
 | Risk | Impact | Mitigation |
 |---|---:|---|
 | Logs leak private data | Critical | Redaction tests, bundle inspection tests, no raw ICS by default |
+| Debug bundle is exposed without auth | Critical | Require authenticated local admin/session access and audit bundle export |
 | Instrumentation breaks CalDAV | High | Middleware-only logging, fail-open if logging persistence fails |
 | Client-specific quirks consume scope | Medium | Document quirks; require 2 of 3 primary clients, Thunderbird optional |
 | Validation event false negatives | Medium | Use operation log + repository state; provide manual retry |
+| Operation logs grow without bound | Medium | Retention cleanup: latest 1,000 operations or 14 days |
 | Debug bundle grows large | Low | Retention limits, compressed bundle, metadata-only default |
 | Sync Health creates anxiety | Low | Explain statuses and next actions clearly |
 
 ---
 
-## 17. Open questions
+## 18. Open questions
 
-- Should app-specific CalDAV passwords be implemented in this PRP or can dev env Basic Auth remain for the first version?
-- What retention default is best: 7 days, last 1,000 operations, or both?
 - Should Sync Health be visible before login for local single-user setups, or authenticated only?
-- Should client fingerprinting normalize known clients into friendly names?
+- Should client fingerprinting normalize additional clients beyond Apple Calendar, Fantastical, DAVx5, and Thunderbird?
 - Should validation event run against the default calendar only?
+- Should post-MVP app-specific CalDAV passwords be per-device, per-client, or both?
 
 ---
 
-## 18. Suggested GitHub issue breakdown
+## 19. Suggested GitHub issue breakdown
 
 1. `feat(server): add CalDAV operation metadata logging`
 2. `feat(server): add sync health repository and summary service`
 3. `feat(api): expose sync health endpoints`
 4. `feat(server): add redacted debug bundle export`
 5. `feat(web): add Sync Health dashboard`
-6. `feat(web): add CalDAV onboarding gate`
+6. `feat(web): add CalDAV onboarding gate using Basic Auth/env credentials`
 7. `test(caldav): add validation-event flow tests`
 8. `test(caldav): add stale ETag, duplicate UID, corrupt ICS diagnostics tests`
-9. `docs(testing): add CalDAV interop results matrix`
-10. `docs(setup): add Apple Calendar, Fantastical, DAVx5 setup recipes`
+9. `test(sync): add health status and retention tests`
+10. `docs(testing): add CalDAV interop results matrix`
+11. `docs(setup): add Apple Calendar, Fantastical, DAVx5 setup recipes`
+12. `post-mvp: design app-specific CalDAV password model`

--- a/docs/prp/enhancement-prps-overview.md
+++ b/docs/prp/enhancement-prps-overview.md
@@ -91,7 +91,7 @@ Raw ICS + ETag correctness
 4. `feat(web): add proposal card`
 5. `feat(web): add diff preview`
 6. `feat(web): add apply and undo flows`
-7. `feat/web): add reject proposal dialog`
+7. `feat(web): add reject proposal dialog`
 8. `test(web): add first-aha UX tests`
 9. `docs(ux): document first aha flow`
 

--- a/docs/prp/enhancement-prps-overview.md
+++ b/docs/prp/enhancement-prps-overview.md
@@ -15,16 +15,19 @@ This document indexes the three next implementation PRPs for sharpening Calendar
 1. **CalDAV Trust, Sync Health, and Interop Gate**
    - Proves the calendar source of truth.
    - Adds diagnostics and onboarding gate.
+   - Uses existing Basic Auth/env credentials for MVP.
    - Required before asking users to trust plan writes.
 
 2. **Planning Safety Skeleton, Diff, Audit Log, and Rollback**
    - Builds the backend trust loop.
    - Requires no real LLM.
    - Gives frontend stable APIs.
+   - Defines the apply response contract used by First Aha UX.
 
 3. **First Aha UX - Agenda, Focus Proposal, Diff Review, and Undo**
    - Turns the backend skeleton into the first visible product moment.
    - Can start with mocked APIs, but should ship after proposal/apply/rollback APIs stabilize.
+   - Do not begin First Aha implementation until PRP 2 API response contracts are stable.
 
 ## Dependency map
 
@@ -33,17 +36,25 @@ CalDAV trust
 ├── Sync Health API
 ├── Debug bundle
 ├── Green Sync onboarding
+├── Basic Auth/env credential guidance
 └── Interop evidence
 
 Planning safety
 ├── Depends on existing EventRepo/CalDAV storage
 ├── Uses ETags from CalDAV foundation
 ├── Adds PlanProposal/Diff/Apply/Rollback
-└── Writes audit log
+├── Adds canonical stale proposal state
+├── Writes audit log
+└── Defines apply response contract
 
 First Aha UX
-├── Depends on Sync Health status
+├── Depends on Sync Health status and green-sync completion
 ├── Depends on proposal/apply/rollback/audit APIs
+├── Depends on PRP 2 apply response contract:
+│   ├── audit_log_entry_id
+│   ├── rollback_available
+│   ├── can_apply
+│   └── applied change summary
 ├── Adds Today dashboard
 └── Delivers first user-visible aha
 ```
@@ -58,6 +69,29 @@ Raw ICS + ETag correctness
 -> Today UI + diff + undo
 ```
 
+## Interop cutline
+
+- Apple Calendar, Fantastical, and DAVx5 must all be represented in `docs/testing/caldav-interop-results.md`.
+- At least two of the three must pass manual CRUD validation for MVP.
+- Non-passing or not-yet-tested clients must be documented with status, reason, and follow-up issue.
+- Thunderbird remains optional for MVP and should be documented if easy.
+
+## Definition of Ready for Dev Execution
+
+Before implementation begins for each PRP:
+
+- [ ] Goals and non-goals are explicit.
+- [ ] MVP vs post-MVP scope is clear.
+- [ ] API contracts are defined.
+- [ ] Data model changes are identified or explicitly not required.
+- [ ] Acceptance criteria are objective and testable.
+- [ ] Manual validation steps are documented.
+- [ ] Cross-PRP dependencies are satisfied.
+- [ ] Privacy/redaction requirements are specified.
+- [ ] No hidden LLM or Todoist dependency exists.
+
+Do not begin First Aha implementation until PRP 2 API response contracts are stable.
+
 ## Suggested epic breakdown
 
 ### Epic 1 - CalDAV trust and diagnostics
@@ -65,59 +99,71 @@ Raw ICS + ETag correctness
 1. `feat(server): add CalDAV operation metadata logging`
 2. `feat(server): add sync health summary service`
 3. `feat(api): expose sync health endpoints`
-4. `feat(server): add redacted debug bundle export`
+4. `feat(server): add redacted authenticated debug bundle export`
 5. `feat(web): add Sync Health dashboard`
-6. `feat(web): add CalDAV onboarding gate`
+6. `feat(web): add CalDAV onboarding gate using Basic Auth/env credentials`
 7. `test(caldav): add validation-event flow tests`
-8. `docs(testing): publish CalDAV interop matrix`
+8. `test(sync): add health status and retention tests`
+9. `docs(testing): publish CalDAV interop matrix`
 
 ### Epic 2 - Planning safety skeleton
 
 1. `feat(planner): add proposal/diff/validation domain types`
-2. `feat(planner): implement deterministic constraint engine`
-3. `feat(planner): implement focus slot finder`
-4. `feat(data): persist proposals and rollback payloads`
-5. `feat(api): add daily proposal endpoint`
-6. `feat(api): add proposal apply endpoint with revalidation`
-7. `feat(api): add rollback endpoint`
-8. `feat(api): add audit log endpoints`
-9. `test(planner): cover constraints, stale proposals, rollback conflicts`
+2. `feat(planner): implement canonical proposal statuses including stale`
+3. `feat(planner): implement deterministic constraint engine`
+4. `feat(planner): implement supported change type validation`
+5. `feat(planner): implement focus slot finder`
+6. `feat(data): persist proposals and rollback payloads`
+7. `feat(api): add daily proposal endpoint`
+8. `feat(api): add proposal apply endpoint with revalidation and response contract`
+9. `feat(api): add rollback endpoint`
+10. `feat(api): add audit log endpoints with redacted responses`
+11. `test(planner): cover constraints, stale proposals, unsupported changes, and rollback conflicts`
 
 ### Epic 3 - First Aha UX
 
 1. `feat(api): add today endpoint`
 2. `feat(web): add Today dashboard`
 3. `feat(web): add agenda timeline`
-4. `feat(web): add proposal card`
+4. `feat(web): add click-to-generate proposal card`
 5. `feat(web): add diff preview`
-6. `feat(web): add apply and undo flows`
-7. `feat(web): add reject proposal dialog`
-8. `test(web): add first-aha UX tests`
-9. `docs(ux): document first aha flow`
+6. `feat(web): add apply flow with sync-health gate`
+7. `feat(web): add undo flow using rollback_available and audit_log_entry_id`
+8. `feat(web): add reject proposal dialog`
+9. `test(web): add first-aha UX tests`
+10. `test(web): add unhealthy sync apply-disabled tests`
+11. `docs(ux): document first aha flow`
 
 ## MVP cutline
 
 ### Must ship
 
 - CalDAV green-sync onboarding gate.
-- Sync Health dashboard.
-- Redacted debug bundle.
-- Interop doc with Apple/Fantastical/DAVx5 results.
+- MVP onboarding using existing Basic Auth/env credentials.
+- Sync Health dashboard with deterministic Healthy / Warning / Critical / Unknown rules.
+- Authenticated redacted debug bundle.
+- Interop doc representing Apple Calendar, Fantastical, and DAVx5, with at least two passing manual CRUD.
 - Deterministic proposal model.
+- Canonical `stale` proposal status.
 - Constraint validation before display and before apply.
 - Machine-readable diff.
 - Human-readable diff.
 - Apply endpoint with ETag revalidation.
+- Apply response with `audit_log_entry_id`, `rollback_available`, `can_apply`, and applied change summary.
 - Audit log entry for every apply.
 - Rollback endpoint with external-change conflict blocking.
+- Audit APIs that do not expose raw ICS by default.
 - Today agenda.
-- One focus block recommendation.
-- Apply and Undo UI.
+- One click-generated focus block recommendation.
+- Apply disabled unless `can_apply`, validation, sync health, and green-sync gates pass.
+- Undo UI shown only when `rollback_available === true`.
+- View audit log link using `audit_log_entry_id`.
 - Rejection reason capture.
 - No raw ICS in default logs/debug bundles.
 
 ### Can defer
 
+- App-specific CalDAV passwords and per-client credentials.
 - Thunderbird interop if Apple/Fantastical/DAVx5 coverage is strong.
 - Full RFC 6578 `sync-collection`.
 - Real LLM planner.
@@ -139,9 +185,11 @@ Raw ICS + ETag correctness
 |---|---|---:|---|
 | Calendar data loss | All | Critical | Raw ICS source of truth, ETags, transactions, interop tests |
 | Privacy leak in logs/debug/audit | CalDAV trust, planning safety | Critical | Redaction by default, tests, raw export opt-in |
+| Debug bundle exposed without auth | CalDAV trust | Critical | Require authenticated local admin/session access |
 | Rollback unsafe after external edits | Planning safety, First Aha UX | High | ETag-at-apply checks before rollback |
-| UI implies AI autonomy | First Aha UX | High | Agenda-first, explicit Apply, clear diff |
-| CalDAV client quirks delay UX | CalDAV trust | Medium | 2-of-3 pass gate, document quirks, defer full RFC 6578 |
+| UI implies AI autonomy | First Aha UX | High | Agenda-first, explicit Apply, clear diff, explicit click-to-generate |
+| Sync unhealthy still allows writes | First Aha UX | High | Hard-disable Apply unless sync and green-sync gates pass |
+| CalDAV client quirks delay UX | CalDAV trust | Medium | 2-of-3 pass gate, document all three, defer full RFC 6578 |
 | Proposal feels underwhelming | First Aha UX | Medium | Make trust the magic: validation, diff, undo, visible calendar write |
 | Backend schema churn | Planning safety | Medium | Store JSON payloads for proposal/rollback while stabilizing |
 | Scope creep into full planner | Planning safety, First Aha UX | High | One focus block only, no Todoist writes, no real LLM |

--- a/docs/prp/enhancement-prps-overview.md
+++ b/docs/prp/enhancement-prps-overview.md
@@ -1,0 +1,147 @@
+# Calendar-app Enhancement PRPs Overview
+
+This document indexes the three next implementation PRPs for sharpening Calendar-app around the MVP wedge:
+
+> A self-hosted calendar source of truth that protects focus time with explainable, reversible AI proposals.
+
+## PRPs
+
+1. [CalDAV Trust, Sync Health, and Interop Gate](./caldav-trust-sync-health-interop-gate.md)
+2. [Planning Safety Skeleton, Diff, Audit Log, and Rollback](./planning-safety-diff-audit-rollback.md)
+3. [First Aha UX - Agenda, Focus Proposal, Diff Review, and Undo](./first-aha-agenda-focus-diff-undo.md)
+
+## Recommended implementation order
+
+1. **CalDAV Trust, Sync Health, and Interop Gate**
+   - Proves the calendar source of truth.
+   - Adds diagnostics and onboarding gate.
+   - Required before asking users to trust plan writes.
+
+2. **Planning Safety Skeleton, Diff, Audit Log, and Rollback**
+   - Builds the backend trust loop.
+   - Requires no real LLM.
+   - Gives frontend stable APIs.
+
+3. **First Aha UX - Agenda, Focus Proposal, Diff Review, and Undo**
+   - Turns the backend skeleton into the first visible product moment.
+   - Can start with mocked APIs, but should ship after proposal/apply/rollback APIs stabilize.
+
+## Dependency map
+
+```text
+CalDAV trust
+├── Sync Health API
+├── Debug bundle
+├── Green Sync onboarding
+└── Interop evidence
+
+Planning safety
+├── Depends on existing EventRepo/CalDAV storage
+├── Uses ETags from CalDAV foundation
+├── Adds PlanProposal/Diff/Apply/Rollback
+└── Writes audit log
+
+First Aha UX
+├── Depends on Sync Health status
+├── Depends on proposal/apply/rollback/audit APIs
+├── Adds Today dashboard
+└── Delivers first user-visible aha
+```
+
+Critical path:
+
+```text
+Raw ICS + ETag correctness
+-> Sync Health / green sync
+-> Deterministic proposal + validation
+-> Apply + audit + rollback
+-> Today UI + diff + undo
+```
+
+## Suggested epic breakdown
+
+### Epic 1 - CalDAV trust and diagnostics
+
+1. `feat(server): add CalDAV operation metadata logging`
+2. `feat(server): add sync health summary service`
+3. `feat(api): expose sync health endpoints`
+4. `feat(server): add redacted debug bundle export`
+5. `feat(web): add Sync Health dashboard`
+6. `feat(web): add CalDAV onboarding gate`
+7. `test(caldav): add validation-event flow tests`
+8. `docs(testing): publish CalDAV interop matrix`
+
+### Epic 2 - Planning safety skeleton
+
+1. `feat(planner): add proposal/diff/validation domain types`
+2. `feat(planner): implement deterministic constraint engine`
+3. `feat(planner): implement focus slot finder`
+4. `feat(data): persist proposals and rollback payloads`
+5. `feat(api): add daily proposal endpoint`
+6. `feat(api): add proposal apply endpoint with revalidation`
+7. `feat(api): add rollback endpoint`
+8. `feat(api): add audit log endpoints`
+9. `test(planner): cover constraints, stale proposals, rollback conflicts`
+
+### Epic 3 - First Aha UX
+
+1. `feat(api): add today endpoint`
+2. `feat(web): add Today dashboard`
+3. `feat(web): add agenda timeline`
+4. `feat(web): add proposal card`
+5. `feat(web): add diff preview`
+6. `feat(web): add apply and undo flows`
+7. `feat/web): add reject proposal dialog`
+8. `test(web): add first-aha UX tests`
+9. `docs(ux): document first aha flow`
+
+## MVP cutline
+
+### Must ship
+
+- CalDAV green-sync onboarding gate.
+- Sync Health dashboard.
+- Redacted debug bundle.
+- Interop doc with Apple/Fantastical/DAVx5 results.
+- Deterministic proposal model.
+- Constraint validation before display and before apply.
+- Machine-readable diff.
+- Human-readable diff.
+- Apply endpoint with ETag revalidation.
+- Audit log entry for every apply.
+- Rollback endpoint with external-change conflict blocking.
+- Today agenda.
+- One focus block recommendation.
+- Apply and Undo UI.
+- Rejection reason capture.
+- No raw ICS in default logs/debug bundles.
+
+### Can defer
+
+- Thunderbird interop if Apple/Fantastical/DAVx5 coverage is strong.
+- Full RFC 6578 `sync-collection`.
+- Real LLM planner.
+- Todoist writes.
+- Todoist read sync in first aha.
+- Multi-option proposal ranking.
+- Drag/drop calendar editing.
+- Week view.
+- Chat interface.
+- Destructive move/delete proposal UI.
+- Slack focus status.
+- Hosted multi-tenant deployment.
+- Advanced recurrence modifications.
+- Preference learning beyond rejection capture.
+
+## Cross-PRP risks
+
+| Risk | Affected PRP | Severity | Mitigation |
+|---|---|---:|---|
+| Calendar data loss | All | Critical | Raw ICS source of truth, ETags, transactions, interop tests |
+| Privacy leak in logs/debug/audit | CalDAV trust, planning safety | Critical | Redaction by default, tests, raw export opt-in |
+| Rollback unsafe after external edits | Planning safety, First Aha UX | High | ETag-at-apply checks before rollback |
+| UI implies AI autonomy | First Aha UX | High | Agenda-first, explicit Apply, clear diff |
+| CalDAV client quirks delay UX | CalDAV trust | Medium | 2-of-3 pass gate, document quirks, defer full RFC 6578 |
+| Proposal feels underwhelming | First Aha UX | Medium | Make trust the magic: validation, diff, undo, visible calendar write |
+| Backend schema churn | Planning safety | Medium | Store JSON payloads for proposal/rollback while stabilizing |
+| Scope creep into full planner | Planning safety, First Aha UX | High | One focus block only, no Todoist writes, no real LLM |

--- a/docs/prp/first-aha-agenda-focus-diff-undo.md
+++ b/docs/prp/first-aha-agenda-focus-diff-undo.md
@@ -13,8 +13,9 @@ The first visible Calendar-app aha should be small, safe, and concrete: Calendar
 
 This PRP turns the backend planning safety skeleton into an agenda-first user experience. It depends on:
 
-- Sync Health status from the CalDAV trust PRP.
+- Sync Health status and green-sync validation from the CalDAV trust PRP.
 - Proposal/diff/apply/audit/rollback APIs from the planning safety PRP.
+- PRP 2's apply response contract, specifically `audit_log_entry_id`, `rollback_available`, `can_apply`, and `applied_changes`.
 
 The experience should work without a real LLM and without Todoist. The point is to make the trust promise visible.
 
@@ -29,14 +30,14 @@ Users need to experience Calendar-app's trust promise in the UI, not just in bac
 ## 3. Goals
 
 - Create Today dashboard with agenda and sync health status.
-- Show one recommended focus block proposal.
+- Show one recommended focus block proposal after an explicit user action.
 - Explain why the slot was chosen.
 - Show constraints checked and validation status.
 - Show a clear diff before apply.
-- Allow apply only when proposal is valid.
-- Show success banner with Undo and View audit log.
+- Enable Apply only when proposal, validation, and sync-health gates pass.
+- Show success banner with Undo and View audit log using the apply response contract.
 - Capture rejection reason.
-- Handle no-slot, unhealthy sync, invalid proposal, apply failure, and rollback failure states.
+- Handle no-slot, unhealthy sync, invalid proposal, stale proposal, apply failure, and rollback failure states.
 
 ---
 
@@ -50,23 +51,48 @@ Users need to experience Calendar-app's trust promise in the UI, not just in bac
 - No destructive move/delete flows in first aha, except placeholders.
 - No mobile-native app.
 - No ambient automatic replanning.
+- No automatic proposal generation on page load for MVP.
 
 ---
 
-## 5. User stories
+## 5. MVP interaction decisions
+
+### Explicit click-to-generate
+
+MVP uses an explicit `Find focus slot` / `Generate proposal` action.
+
+The first aha should not auto-generate and present changes before the user asks. This keeps the experience trust-building and avoids surprising users.
+
+### Apply enablement rule
+
+When `sync_status != healthy` or green-sync validation is incomplete, proposal generation may be shown for preview only, but Apply must be disabled with a link to Sync Health/onboarding.
+
+Apply may be enabled only when all of the following are true:
+
+- `can_apply === true`
+- `validation_result.valid === true`
+- `sync_status === healthy`
+- green-sync validation is complete
+
+The frontend must not infer rollback availability from local state. It must use `rollback_available` from the apply response.
+
+---
+
+## 6. User stories
 
 1. As a user, I can open Today and see my agenda plus sync health.
-2. As a user, I see one suggested protected focus block that fits my day.
+2. As a user, I can explicitly click to find one suggested protected focus block that fits my day.
 3. As a user, I can understand why the slot was chosen and what constraints passed before applying.
 4. As a user, I can open a diff and explain what will change.
-5. As a user, I can apply the proposal only after confirmation.
-6. As a user, I can undo the applied focus block if nothing changed externally.
-7. As a user, I can reject a bad proposal with a structured reason.
-8. As a user, I understand what to do when sync is unhealthy, no slot exists, proposal is invalid, apply fails, or rollback is blocked.
+5. As a user, I can apply the proposal only after confirmation and only when sync health is healthy.
+6. As a user, I can undo the applied focus block if the apply response says rollback is available and nothing changed externally.
+7. As a user, I can use View audit log to open the audit entry returned by apply.
+8. As a user, I can reject a bad proposal with a structured reason.
+9. As a user, I understand what to do when sync is unhealthy, no slot exists, proposal is invalid, proposal is stale, apply fails, or rollback is blocked.
 
 ---
 
-## 6. Functional requirements
+## 7. Functional requirements
 
 ### FR1 - Daily dashboard
 
@@ -82,7 +108,7 @@ Dashboard sections:
    - Date.
    - Sync status.
    - Calendar source: Calendar-app CalDAV.
-   - Optional LLM state if visible: not configured / configured.
+   - Planner state: deterministic planner / LLM not configured / configured if visible.
 2. Agenda
    - Today's events sorted by time.
    - Focus blocks visually distinguished.
@@ -95,11 +121,12 @@ Dashboard sections:
    - Protected focus blocks today.
    - Interruptions detected, if any.
 5. Recommended plan card
-   - One proposal.
+   - One proposal after explicit user action.
    - Explanation.
    - Validation.
    - Diff summary.
    - Actions.
+   - Generated/expiration timestamp.
 
 ### FR2 - Today API dependency
 
@@ -124,6 +151,7 @@ Example response:
 {
   "date": "2026-04-25",
   "sync_status": "healthy",
+  "green_sync_completed": true,
   "calendar_source": "Calendar-app CalDAV",
   "events": [
     {
@@ -148,11 +176,23 @@ Example response:
 
 ### FR3 - First proposal card
 
+Before generation, show an explicit action:
+
+```text
+Ready to protect focus time?
+
+[Find focus slot]
+```
+
 Proposal card must show:
 
 ```text
 Suggested protection:
 Add "Deep Work" from 9:30-11:30
+
+Using deterministic planner. No LLM data sent.
+
+Generated 2 minutes ago · Expires in 8 minutes
 
 Why:
 - Longest open morning slot
@@ -173,10 +213,11 @@ Requirements:
 
 - Use deterministic proposal from planning safety PRP.
 - Show only one recommended proposal.
-- Do not show Apply if `validation_result.valid=false`.
-- If proposal expires, show `Regenerate proposal`.
-- If sync status is unhealthy, show warning before proposal generation: `Calendar sync is unhealthy. Fix sync before applying plans.`
-- If no LLM key exists, do not block first proposal; show `Using deterministic planner.`
+- Do not show or enable Apply unless the Apply enablement rule passes.
+- If proposal expires, show `Proposal expired. Regenerate before applying.`
+- If proposal becomes stale, affected event ETags changed, or sync state changed after generation, show `Calendar changed. Regenerate before applying.`
+- If sync status is unhealthy, show warning before proposal generation: `Calendar sync is unhealthy. You can preview a proposal, but Apply is disabled until sync is healthy.`
+- If no LLM key exists, do not block first proposal; show `Using deterministic planner. No LLM data sent.`
 
 ### FR4 - Explanation panel
 
@@ -247,6 +288,7 @@ Technical details expandable:
 - Calendar ID.
 - Validation checked timestamp.
 - ETag refs count.
+- Generated at.
 - Expires at.
 
 ### FR7 - Apply confirmation
@@ -254,14 +296,20 @@ Technical details expandable:
 Apply behavior:
 
 - Button label: `Apply focus block`.
+- Apply is disabled unless the Apply enablement rule passes.
+- Disabled Apply state links the user to Sync Health or onboarding remediation.
 - On click, show lightweight confirmation if only adding a focus block.
 - Strong confirmation is reserved for destructive changes.
 - Loading state disables buttons and shows `Revalidating and applying...`.
 
-Success:
+Success response handling:
 
-- Add focus block to agenda.
-- Show banner:
+- Use `audit_log_entry_id` from the apply response for `View audit log`.
+- Show Undo only when `rollback_available === true` in the apply response.
+- Use `applied_changes` from the apply response to update/refetch the agenda.
+- Do not infer rollback availability from local state.
+
+Success banner:
 
 ```text
 Focus block added.
@@ -269,24 +317,25 @@ Focus block added.
 [Undo] [View audit log]
 ```
 
-Failure:
+Failure handling:
 
-- Show specific error:
-  - Stale proposal.
-  - Validation failed.
-  - ETag changed.
-  - Server error.
-  - Sync unhealthy.
+- Stale proposal: `Calendar changed. Regenerate before applying.`
+- Expired proposal: `Proposal expired. Regenerate before applying.`
+- Validation failed: show violations and no Apply.
+- ETag changed: use stale proposal copy.
+- Server error: show retry-safe error.
+- Sync unhealthy: link to Sync Health.
 
 ### FR8 - Undo after apply
 
 Undo action:
 
-- Calls `/api/v1/plan/rollback`.
+- Calls `/api/v1/plan/rollback` with `proposal_id` or `audit_log_entry_id` from the apply result.
+- Show Undo only when `rollback_available === true`.
 
 On success:
 
-- Remove focus block from agenda.
+- Remove focus block from agenda after server confirms rollback.
 - Update proposal state to rolled back.
 - Show:
 
@@ -302,7 +351,7 @@ On blocked rollback:
 Undo blocked because this event changed in another calendar client after apply. Review the audit log for details.
 ```
 
-- Provide link to audit log entry.
+- Provide link to audit log entry using the known `audit_log_entry_id`.
 
 ### FR9 - Reject flow
 
@@ -340,34 +389,55 @@ Required states:
 3. Sync unhealthy
    - `Sync health needs attention before applying plans.`
    - Link to Sync Health.
+   - Apply disabled.
 4. Proposal invalid
    - Show violations; no Apply.
-5. Apply failed
+5. Proposal stale
+   - `Calendar changed. Regenerate before applying.`
+   - No Apply.
+6. Apply failed
    - Show error and next step.
-6. Rollback failed
+7. Rollback failed
    - Show reason and link to audit log.
-7. LLM not configured
-   - `Using deterministic planner. LLM setup is optional.`
-8. Proposal expired
-   - `This proposal expired because your calendar may have changed.`
+8. LLM not configured
+   - `Using deterministic planner. No LLM data sent.`
+9. Proposal expired
+   - `Proposal expired. Regenerate before applying.`
    - Show regenerate action.
+
+### FR11 - Proposal expiration display
+
+Proposal card should show when it was generated and/or when it expires.
+
+Example:
+
+```text
+Generated 2 minutes ago · Expires in 8 minutes
+```
+
+If expired:
+
+```text
+Proposal expired. Regenerate before applying.
+```
 
 ---
 
-## 7. Non-functional requirements
+## 8. Non-functional requirements
 
 - Trust clarity: user must be able to identify what will change before applying.
 - Accessibility: keyboard-accessible modal/drawer, focus trap, ARIA labels, WCAG 2.1 AA contrast.
 - Responsiveness: desktop-first, responsive enough for mobile review/apply.
 - Performance: Today dashboard loads under 1s locally for typical single-user data.
 - No silent writes: every apply originates from explicit user action.
+- No surprise proposals: first aha requires explicit click-to-generate.
 - Resilience: UI handles API errors without losing local state.
 - Privacy: do not expose raw ICS in technical details.
 - State correctness: agenda updates after apply/undo via refetch or local mutation confirmed by server response.
 
 ---
 
-## 8. Technical approach
+## 9. Technical approach
 
 ### Frontend architecture
 
@@ -380,6 +450,7 @@ TodayPage
   AgendaTimeline
   AvailabilitySummary
   FocusProtectionSummary
+  GenerateProposalButton
   ProposalCard
   ProposalExplanation
   ValidationBadge
@@ -409,6 +480,16 @@ Query invalidation:
 - After apply: invalidate `today`, `proposal`, and `audit-log`.
 - After rollback: invalidate `today`, `proposal`, and `audit-log`.
 
+Apply button derived state:
+
+```ts
+const applyEnabled =
+  proposal.can_apply === true &&
+  proposal.validation_result.valid === true &&
+  syncHealth.status === "healthy" &&
+  syncHealth.green_sync_completed === true;
+```
+
 ### Backend additions
 
 Add `GET /api/v1/today` if missing:
@@ -420,7 +501,7 @@ Add `GET /api/v1/today` if missing:
 
 ---
 
-## 9. Files likely to change
+## 10. Files likely to change
 
 Frontend:
 
@@ -430,6 +511,7 @@ web/src/components/today/TodayHeader.tsx
 web/src/components/today/AgendaTimeline.tsx
 web/src/components/today/AvailabilitySummary.tsx
 web/src/components/today/FocusProtectionSummary.tsx
+web/src/components/plan/GenerateProposalButton.tsx
 web/src/components/plan/ProposalCard.tsx
 web/src/components/plan/ProposalExplanation.tsx
 web/src/components/plan/ValidationBadge.tsx
@@ -470,7 +552,7 @@ docs/ux/first-aha-flow.md
 
 ---
 
-## 10. API changes
+## 11. API changes
 
 Add if missing:
 
@@ -490,9 +572,21 @@ GET  /api/v1/sync-health
 GET  /api/v1/audit-log/{entry_id}
 ```
 
+Apply response requirements inherited from PRP 2:
+
+- `status`.
+- `proposal_id`.
+- `audit_log_entry_id` when apply succeeds.
+- `rollback_available`.
+- `summary`.
+- `applied_changes`.
+- `can_apply`.
+- `error_code` on failure.
+- `message` on failure.
+
 ---
 
-## 11. Database/schema changes
+## 12. Database/schema changes
 
 No required new schema if the CalDAV trust and planning safety PRPs are complete.
 
@@ -513,7 +607,7 @@ CREATE TABLE proposal_rejections (
 
 ---
 
-## 12. UX changes
+## 13. UX changes
 
 Primary UX route: `/today`.
 
@@ -536,7 +630,8 @@ Left/main:
 
 Right/side or top card:
 
-- Suggested protection card.
+- Find focus slot CTA.
+- Suggested protection card after generation.
 
 Below or side:
 
@@ -547,7 +642,10 @@ Below or side:
 
 Use plain language:
 
+- `Find focus slot`
 - `Suggested protection`
+- `Using deterministic planner. No LLM data sent.`
+- `Generated 2 minutes ago · Expires in 8 minutes`
 - `Why this slot`
 - `Validation passed`
 - `What will change`
@@ -560,9 +658,32 @@ Avoid:
 - `Autopilot`
 - `We changed your calendar`
 
+### Stale / expired recovery copy
+
+Use:
+
+```text
+Calendar changed. Regenerate before applying.
+```
+
+when:
+
+- proposal is stale;
+- affected event ETags changed;
+- sync state changed after proposal generation.
+
+Use:
+
+```text
+Proposal expired. Regenerate before applying.
+```
+
+when the proposal expiration time has passed.
+
 ### Accessibility requirements
 
 - All buttons keyboard reachable.
+- Disabled Apply state remains understandable and includes remediation link.
 - Diff drawer closes with Escape.
 - Focus returns to opener after drawer closes.
 - Validation status announced to screen readers.
@@ -571,34 +692,41 @@ Avoid:
 
 ---
 
-## 13. Test plan
+## 14. Test plan
 
 Frontend unit/component tests:
 
 - Today dashboard renders agenda.
-- Sync status badge renders healthy/warning/critical.
-- Proposal card renders explanation and validation.
+- Sync status badge renders healthy/warning/critical/unknown.
+- Proposal generation requires explicit click.
+- Proposal card renders explanation, deterministic planner copy, generated timestamp, expiration, and validation.
 - Apply hidden/disabled for invalid proposal.
+- Apply disabled when Sync Health is warning, critical, unknown, or green-sync validation is incomplete.
+- Disabled Apply state links the user to Sync Health or onboarding remediation.
+- Apply enabled only when `can_apply`, validation, sync health, and green-sync gates pass.
 - Diff preview opens and groups changes.
-- Apply success shows Undo banner.
+- Apply success uses `audit_log_entry_id` for View audit log.
+- Undo is shown only when `rollback_available === true`.
 - Undo success removes banner/refetches agenda.
 - Rollback blocked shows clear error.
 - Reject dialog submits reason.
 - No open slot empty state renders.
+- Stale proposal copy renders.
 - Sync unhealthy warning links to Sync Health.
 
 Frontend integration tests:
 
-- Mock full happy path: load today, generate proposal, open diff, apply, see success, undo.
+- Mock full happy path: load today, click Find focus slot, generate proposal, open diff, apply, see success, view audit log link, undo.
 - Mock stale proposal apply failure.
 - Mock invalid proposal.
+- Mock unhealthy sync state and confirm Apply disabled.
 
 Backend tests:
 
 - `GET /api/v1/today` returns events and availability.
 - Availability excludes fixed events.
 - Availability computes longest open slot.
-- Today endpoint includes sync status.
+- Today endpoint includes sync status and green-sync completion.
 
 UX test:
 
@@ -608,7 +736,7 @@ UX test:
 
 ---
 
-## 14. Manual validation steps
+## 15. Manual validation steps
 
 1. Complete green sync from the CalDAV trust PRP.
 2. Seed today calendar:
@@ -618,35 +746,46 @@ UX test:
 3. Open `/today`.
 4. Confirm agenda appears.
 5. Confirm Sync Health status appears.
-6. Generate/view proposal.
+6. Click `Find focus slot`.
 7. Confirm proposal suggests one safe focus block.
-8. Open diff.
-9. Confirm diff says only one event will be added.
-10. Apply.
-11. Confirm focus block appears in agenda and external CalDAV client.
-12. Confirm audit log entry exists.
-13. Click Undo.
-14. Confirm focus block disappears from agenda and external CalDAV client.
-15. Repeat with intentionally invalid proposal fixture; confirm no Apply.
-16. Repeat with external edit after apply; confirm Undo blocked clearly.
+8. Confirm deterministic planner copy and proposal expiration display appear.
+9. Open diff.
+10. Confirm diff says only one event will be added.
+11. Apply.
+12. Confirm focus block appears in agenda and external CalDAV client.
+13. Confirm success banner uses `audit_log_entry_id` for View audit log.
+14. Confirm Undo appears only when `rollback_available=true`.
+15. Click Undo.
+16. Confirm focus block disappears from agenda and external CalDAV client.
+17. Repeat with intentionally invalid proposal fixture; confirm no Apply.
+18. Repeat with unhealthy sync state; confirm proposal can preview but Apply is disabled and links to remediation.
+19. Repeat with external edit after apply; confirm Undo blocked clearly.
 
 ---
 
-## 15. Acceptance criteria
+## 16. Acceptance criteria
 
 - User can view Today agenda.
 - User can see Sync Health status.
-- User can generate or view one proposed focus block.
+- User can explicitly generate or view one proposed focus block via `Find focus slot` / `Generate proposal`.
 - Proposal includes explanation and validation status.
+- Proposal includes deterministic planner copy: `Using deterministic planner. No LLM data sent.`
+- Proposal shows generated/expiration timing.
 - Proposal shows constraints checked.
 - User can open diff preview.
-- User can apply the proposal.
+- Apply is disabled when Sync Health is warning, critical, unknown, or green-sync validation is incomplete.
+- Disabled Apply state links the user to Sync Health or onboarding remediation.
+- Tests cover healthy and unhealthy sync states.
+- User can apply the proposal only when `can_apply === true`, `validation_result.valid === true`, `sync_status === healthy`, and green-sync validation is complete.
 - Applied focus block appears on the calendar.
 - Audit log entry is created.
-- Success banner includes Undo and View audit log.
+- Success banner includes View audit log using `audit_log_entry_id` from apply response.
+- Success banner includes Undo only when `rollback_available === true`.
 - User can undo the apply if no external conflict exists.
 - Undo blocked state is clear when external ETag changed.
 - Invalid proposal does not show actionable Apply.
+- Stale proposal shows `Calendar changed. Regenerate before applying.`
+- Expired proposal shows `Proposal expired. Regenerate before applying.`
 - Reject flow captures structured reason and optional free text.
 - No LLM key is required for first aha.
 - UX test passes: user can explain what will change before applying.
@@ -655,39 +794,44 @@ UX test:
 
 ---
 
-## 16. Risks and mitigations
+## 17. Risks and mitigations
 
 | Risk | Impact | Mitigation |
 |---|---:|---|
 | First aha feels too small | Medium | Make trust visible: why, validation, diff, undo |
 | UI overexplains | Medium | Default concise card; technical details expandable |
 | Apply race causes failure | Medium | Treat stale proposal as expected state with regenerate CTA |
+| Sync unhealthy still allows writes | High | Hard disable Apply unless sync and green-sync gates pass |
 | Undo blocked surprises user | Medium | Explain external changes and link to audit log |
 | Agenda UI becomes scope creep | High | No drag/drop; no week view; Today only |
 | No-slot state feels like failure | Low | Explain blockers and suggest retry/edit preferences later |
 
 ---
 
-## 17. Open questions
+## 18. Open questions
 
 - Should the first focus block default to 90 minutes or 2 hours?
 - Should `Deep Work` title be configurable before apply or fixed for MVP?
 - Should focus blocks use a dedicated calendar if one exists?
-- Should the UI auto-generate a proposal on page load or require `Find focus slot` click?
 - Should success banner persist until dismissed or disappear after navigation?
+
+Resolved for MVP:
+
+- Proposal generation is explicit click-to-generate, not automatic on page load.
 
 ---
 
-## 18. Suggested GitHub issue breakdown
+## 19. Suggested GitHub issue breakdown
 
 1. `feat(api): add today dashboard endpoint`
 2. `feat(web): add Today dashboard route`
 3. `feat(web): add agenda timeline component`
 4. `feat(web): add sync status and availability summaries`
-5. `feat(web): add proposal card with explanation and validation`
+5. `feat(web): add click-to-generate proposal card with explanation and validation`
 6. `feat(web): add diff preview drawer`
-7. `feat(web): add apply proposal flow`
-8. `feat(web): add undo rollback banner`
+7. `feat(web): add apply proposal flow with sync-health gate`
+8. `feat(web): add undo rollback banner using apply response contract`
 9. `feat(web): add rejection reason dialog`
 10. `test(web): add first-aha happy path and error state tests`
-11. `docs(ux): document first aha flow`
+11. `test(web): add unhealthy sync apply-disabled tests`
+12. `docs(ux): document first aha flow`

--- a/docs/prp/first-aha-agenda-focus-diff-undo.md
+++ b/docs/prp/first-aha-agenda-focus-diff-undo.md
@@ -1,0 +1,693 @@
+# PRP: First Aha UX - Agenda, Focus Proposal, Diff Review, and Undo
+
+**Type:** Implementation PRP / Product Requirements Prompt  
+**Target Team:** Frontend + Backend API + UX QA  
+**Status:** Proposed  
+**Priority:** MVP user-visible trust loop
+
+---
+
+## 1. Context
+
+The first visible Calendar-app aha should be small, safe, and concrete: Calendar-app finds one open slot, proposes one protected focus block, validates it, shows the diff, applies after confirmation, logs it, and can undo it.
+
+This PRP turns the backend planning safety skeleton into an agenda-first user experience. It depends on:
+
+- Sync Health status from the CalDAV trust PRP.
+- Proposal/diff/apply/audit/rollback APIs from the planning safety PRP.
+
+The experience should work without a real LLM and without Todoist. The point is to make the trust promise visible.
+
+---
+
+## 2. Problem statement
+
+Users need to experience Calendar-app's trust promise in the UI, not just in backend safety code. A chat-first or full-day planning experience is too broad for the first demo. The MVP should show one validated focus block proposal in an agenda-first dashboard, with visible reasoning, diff, apply, audit, and undo.
+
+---
+
+## 3. Goals
+
+- Create Today dashboard with agenda and sync health status.
+- Show one recommended focus block proposal.
+- Explain why the slot was chosen.
+- Show constraints checked and validation status.
+- Show a clear diff before apply.
+- Allow apply only when proposal is valid.
+- Show success banner with Undo and View audit log.
+- Capture rejection reason.
+- Handle no-slot, unhealthy sync, invalid proposal, apply failure, and rollback failure states.
+
+---
+
+## 4. Non-goals
+
+- No chat-first interface.
+- No multiple alternatives required.
+- No real LLM required.
+- No Todoist dependency required.
+- No complex drag/drop calendar editing.
+- No destructive move/delete flows in first aha, except placeholders.
+- No mobile-native app.
+- No ambient automatic replanning.
+
+---
+
+## 5. User stories
+
+1. As a user, I can open Today and see my agenda plus sync health.
+2. As a user, I see one suggested protected focus block that fits my day.
+3. As a user, I can understand why the slot was chosen and what constraints passed before applying.
+4. As a user, I can open a diff and explain what will change.
+5. As a user, I can apply the proposal only after confirmation.
+6. As a user, I can undo the applied focus block if nothing changed externally.
+7. As a user, I can reject a bad proposal with a structured reason.
+8. As a user, I understand what to do when sync is unhealthy, no slot exists, proposal is invalid, apply fails, or rollback is blocked.
+
+---
+
+## 6. Functional requirements
+
+### FR1 - Daily dashboard
+
+Add route:
+
+```text
+/today
+```
+
+Dashboard sections:
+
+1. Header
+   - Date.
+   - Sync status.
+   - Calendar source: Calendar-app CalDAV.
+   - Optional LLM state if visible: not configured / configured.
+2. Agenda
+   - Today's events sorted by time.
+   - Focus blocks visually distinguished.
+   - Current time marker if simple.
+3. Availability summary
+   - Total open working time.
+   - Usable focus time.
+   - Longest open slot.
+4. Focus protection summary
+   - Protected focus blocks today.
+   - Interruptions detected, if any.
+5. Recommended plan card
+   - One proposal.
+   - Explanation.
+   - Validation.
+   - Diff summary.
+   - Actions.
+
+### FR2 - Today API dependency
+
+Use these endpoints:
+
+```http
+GET  /api/v1/today?date=YYYY-MM-DD
+POST /api/v1/plan/daily
+GET  /api/v1/plan/proposals/{proposal_id}
+POST /api/v1/plan/apply
+POST /api/v1/plan/rollback
+POST /api/v1/plan/proposals/{proposal_id}/reject
+GET  /api/v1/sync-health
+GET  /api/v1/audit-log/{entry_id}
+```
+
+If `GET /api/v1/today` does not exist yet, add it in this PRP.
+
+Example response:
+
+```json
+{
+  "date": "2026-04-25",
+  "sync_status": "healthy",
+  "calendar_source": "Calendar-app CalDAV",
+  "events": [
+    {
+      "uid": "evt_1",
+      "summary": "Standup",
+      "start_time": "2026-04-25T08:30:00-04:00",
+      "end_time": "2026-04-25T09:00:00-04:00",
+      "kind": "meeting",
+      "protection_level": "normal"
+    }
+  ],
+  "availability": {
+    "usable_focus_time_minutes": 150,
+    "longest_open_slot_minutes": 120
+  },
+  "focus_summary": {
+    "protected_blocks_count": 0,
+    "interrupted_blocks_count": 0
+  }
+}
+```
+
+### FR3 - First proposal card
+
+Proposal card must show:
+
+```text
+Suggested protection:
+Add "Deep Work" from 9:30-11:30
+
+Why:
+- Longest open morning slot
+- No fixed conflicts
+- Inside configured working hours
+- Preserves lunch and existing meetings
+
+Validation:
+Passed
+
+Changes:
++ Add focus block: Deep Work, 9:30-11:30
+
+[Show diff] [Apply] [Reject]
+```
+
+Requirements:
+
+- Use deterministic proposal from planning safety PRP.
+- Show only one recommended proposal.
+- Do not show Apply if `validation_result.valid=false`.
+- If proposal expires, show `Regenerate proposal`.
+- If sync status is unhealthy, show warning before proposal generation: `Calendar sync is unhealthy. Fix sync before applying plans.`
+- If no LLM key exists, do not block first proposal; show `Using deterministic planner.`
+
+### FR4 - Explanation panel
+
+Show `Why this slot?` with:
+
+- Slot selection reason.
+- Constraints checked.
+- Tradeoffs/assumptions.
+- Existing events preserved.
+- Working hours used.
+- Focus duration used.
+
+Example:
+
+```text
+Why this slot?
+This is the longest open morning slot inside your working hours. It does not overlap fixed events and leaves lunch untouched.
+```
+
+### FR5 - Validation status
+
+Show:
+
+- Passed / Failed / Warning.
+- Checked timestamp.
+- Constraint list:
+  - Time conflicts.
+  - Working hours.
+  - Immovable events.
+  - Protected focus blocks.
+  - Minimum focus duration.
+
+If invalid:
+
+- Disable Apply.
+- Show each violation.
+- Provide `Regenerate` if endpoint is available.
+- Provide `Reject` with reason.
+
+### FR6 - Diff preview
+
+Add a modal/drawer or inline expandable panel.
+
+Grouped sections:
+
+- Add.
+- Move.
+- Delete.
+- Update.
+- Todoist update placeholder.
+- Message draft placeholder.
+
+MVP content likely only:
+
+```text
+Add
++ Focus block: Deep Work
+  Time: 9:30-11:30
+  Calendar: Default
+  Protection: Protected
+```
+
+Technical details expandable:
+
+- Proposal ID.
+- Change ID.
+- UID.
+- Calendar ID.
+- Validation checked timestamp.
+- ETag refs count.
+- Expires at.
+
+### FR7 - Apply confirmation
+
+Apply behavior:
+
+- Button label: `Apply focus block`.
+- On click, show lightweight confirmation if only adding a focus block.
+- Strong confirmation is reserved for destructive changes.
+- Loading state disables buttons and shows `Revalidating and applying...`.
+
+Success:
+
+- Add focus block to agenda.
+- Show banner:
+
+```text
+Focus block added.
+
+[Undo] [View audit log]
+```
+
+Failure:
+
+- Show specific error:
+  - Stale proposal.
+  - Validation failed.
+  - ETag changed.
+  - Server error.
+  - Sync unhealthy.
+
+### FR8 - Undo after apply
+
+Undo action:
+
+- Calls `/api/v1/plan/rollback`.
+
+On success:
+
+- Remove focus block from agenda.
+- Update proposal state to rolled back.
+- Show:
+
+```text
+Focus block removed. Your calendar is back to its previous state.
+```
+
+On blocked rollback:
+
+- Show:
+
+```text
+Undo blocked because this event changed in another calendar client after apply. Review the audit log for details.
+```
+
+- Provide link to audit log entry.
+
+### FR9 - Reject flow
+
+Reject button opens a small dialog.
+
+Structured reasons:
+
+- Bad time.
+- Too long.
+- Too short.
+- Conflicts with preference.
+- Not enough context.
+- Other.
+
+Free text optional.
+
+POST rejection to backend.
+
+After reject:
+
+- Hide Apply.
+- Show `Proposal rejected`.
+- Optional `Generate another` placeholder or enabled if endpoint supports it.
+
+### FR10 - Empty and error states
+
+Required states:
+
+1. No open focus slot
+   - `No safe focus slot found today.`
+   - Explain top blockers.
+2. Calendar not synced
+   - `Connect a CalDAV client and reach green sync first.`
+   - Link to onboarding.
+3. Sync unhealthy
+   - `Sync health needs attention before applying plans.`
+   - Link to Sync Health.
+4. Proposal invalid
+   - Show violations; no Apply.
+5. Apply failed
+   - Show error and next step.
+6. Rollback failed
+   - Show reason and link to audit log.
+7. LLM not configured
+   - `Using deterministic planner. LLM setup is optional.`
+8. Proposal expired
+   - `This proposal expired because your calendar may have changed.`
+   - Show regenerate action.
+
+---
+
+## 7. Non-functional requirements
+
+- Trust clarity: user must be able to identify what will change before applying.
+- Accessibility: keyboard-accessible modal/drawer, focus trap, ARIA labels, WCAG 2.1 AA contrast.
+- Responsiveness: desktop-first, responsive enough for mobile review/apply.
+- Performance: Today dashboard loads under 1s locally for typical single-user data.
+- No silent writes: every apply originates from explicit user action.
+- Resilience: UI handles API errors without losing local state.
+- Privacy: do not expose raw ICS in technical details.
+- State correctness: agenda updates after apply/undo via refetch or local mutation confirmed by server response.
+
+---
+
+## 8. Technical approach
+
+### Frontend architecture
+
+Components:
+
+```text
+TodayPage
+  TodayHeader
+  SyncStatusBadge
+  AgendaTimeline
+  AvailabilitySummary
+  FocusProtectionSummary
+  ProposalCard
+  ProposalExplanation
+  ValidationBadge
+  ConstraintChecklist
+  DiffPreviewDrawer
+  ApplyConfirmation
+  UndoBanner
+  RejectProposalDialog
+  EmptyStatePanel
+  ErrorStatePanel
+```
+
+State handling:
+
+- TanStack Query:
+  - `useToday(date)`.
+  - `useSyncHealth()`.
+  - `useDailyProposal(date)`.
+  - `useProposal(proposalId)`.
+  - `useApplyProposal()`.
+  - `useRollbackProposal()`.
+  - `useRejectProposal()`.
+- Zustand only if needed for UI drawer/dialog state.
+
+Query invalidation:
+
+- After apply: invalidate `today`, `proposal`, and `audit-log`.
+- After rollback: invalidate `today`, `proposal`, and `audit-log`.
+
+### Backend additions
+
+Add `GET /api/v1/today` if missing:
+
+- Uses EventRepo to list events by date.
+- Uses SyncHealthService for status summary.
+- Computes availability from working hours and events.
+- Computes focus summary.
+
+---
+
+## 9. Files likely to change
+
+Frontend:
+
+```text
+web/src/pages/TodayPage.tsx
+web/src/components/today/TodayHeader.tsx
+web/src/components/today/AgendaTimeline.tsx
+web/src/components/today/AvailabilitySummary.tsx
+web/src/components/today/FocusProtectionSummary.tsx
+web/src/components/plan/ProposalCard.tsx
+web/src/components/plan/ProposalExplanation.tsx
+web/src/components/plan/ValidationBadge.tsx
+web/src/components/plan/ConstraintChecklist.tsx
+web/src/components/plan/DiffPreviewDrawer.tsx
+web/src/components/plan/RejectProposalDialog.tsx
+web/src/components/plan/UndoBanner.tsx
+web/src/components/common/EmptyStatePanel.tsx
+web/src/components/common/ErrorStatePanel.tsx
+web/src/lib/api.ts
+web/src/lib/types.ts
+web/src/App.tsx
+```
+
+Backend:
+
+```text
+server/internal/api/today.go
+server/internal/api/plan.go
+server/internal/planner/slot_finder.go
+server/internal/planner/proposal_service.go
+server/internal/api/today_test.go
+```
+
+Tests:
+
+```text
+web/src/pages/TodayPage.test.tsx
+web/src/components/plan/*.test.tsx
+server/internal/api/today_test.go
+```
+
+Docs:
+
+```text
+docs/ux/first-aha-flow.md
+```
+
+---
+
+## 10. API changes
+
+Add if missing:
+
+```http
+GET /api/v1/today?date=YYYY-MM-DD
+```
+
+Use from dependency PRPs:
+
+```http
+POST /api/v1/plan/daily
+GET  /api/v1/plan/proposals/{proposal_id}
+POST /api/v1/plan/apply
+POST /api/v1/plan/rollback
+POST /api/v1/plan/proposals/{proposal_id}/reject
+GET  /api/v1/sync-health
+GET  /api/v1/audit-log/{entry_id}
+```
+
+---
+
+## 11. Database/schema changes
+
+No required new schema if the CalDAV trust and planning safety PRPs are complete.
+
+Optional if rejection reason is not included in the planning safety PRP:
+
+```sql
+CREATE TABLE proposal_rejections (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER NOT NULL,
+  proposal_id TEXT NOT NULL,
+  reason_code TEXT NOT NULL,
+  free_text TEXT,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+  FOREIGN KEY (proposal_id) REFERENCES plan_proposals(id) ON DELETE CASCADE
+);
+```
+
+---
+
+## 12. UX changes
+
+Primary UX route: `/today`.
+
+Screen-level requirements:
+
+### Today dashboard
+
+Top row:
+
+```text
+Today: Sat Apr 25
+Sync: Healthy
+Calendar source: Calendar-app CalDAV
+Planner: Deterministic
+```
+
+Left/main:
+
+- Agenda timeline.
+
+Right/side or top card:
+
+- Suggested protection card.
+
+Below or side:
+
+- Availability summary.
+- Focus protection summary.
+
+### Proposal card copy
+
+Use plain language:
+
+- `Suggested protection`
+- `Why this slot`
+- `Validation passed`
+- `What will change`
+- `Apply focus block`
+- `Reject`
+
+Avoid:
+
+- `AI optimized your schedule`
+- `Autopilot`
+- `We changed your calendar`
+
+### Accessibility requirements
+
+- All buttons keyboard reachable.
+- Diff drawer closes with Escape.
+- Focus returns to opener after drawer closes.
+- Validation status announced to screen readers.
+- Loading states use `aria-busy`.
+- Error banners use `role="alert"`.
+
+---
+
+## 13. Test plan
+
+Frontend unit/component tests:
+
+- Today dashboard renders agenda.
+- Sync status badge renders healthy/warning/critical.
+- Proposal card renders explanation and validation.
+- Apply hidden/disabled for invalid proposal.
+- Diff preview opens and groups changes.
+- Apply success shows Undo banner.
+- Undo success removes banner/refetches agenda.
+- Rollback blocked shows clear error.
+- Reject dialog submits reason.
+- No open slot empty state renders.
+- Sync unhealthy warning links to Sync Health.
+
+Frontend integration tests:
+
+- Mock full happy path: load today, generate proposal, open diff, apply, see success, undo.
+- Mock stale proposal apply failure.
+- Mock invalid proposal.
+
+Backend tests:
+
+- `GET /api/v1/today` returns events and availability.
+- Availability excludes fixed events.
+- Availability computes longest open slot.
+- Today endpoint includes sync status.
+
+UX test:
+
+- Give user a proposal screen.
+- Ask: `What will change if you click Apply?`
+- Pass if user says it will add a Deep Work focus block from X to Y and does not think existing events will move/delete.
+
+---
+
+## 14. Manual validation steps
+
+1. Complete green sync from the CalDAV trust PRP.
+2. Seed today calendar:
+   - Standup 08:30-09:00.
+   - Lunch 12:00-13:00.
+   - Meeting 14:00-15:00.
+3. Open `/today`.
+4. Confirm agenda appears.
+5. Confirm Sync Health status appears.
+6. Generate/view proposal.
+7. Confirm proposal suggests one safe focus block.
+8. Open diff.
+9. Confirm diff says only one event will be added.
+10. Apply.
+11. Confirm focus block appears in agenda and external CalDAV client.
+12. Confirm audit log entry exists.
+13. Click Undo.
+14. Confirm focus block disappears from agenda and external CalDAV client.
+15. Repeat with intentionally invalid proposal fixture; confirm no Apply.
+16. Repeat with external edit after apply; confirm Undo blocked clearly.
+
+---
+
+## 15. Acceptance criteria
+
+- User can view Today agenda.
+- User can see Sync Health status.
+- User can generate or view one proposed focus block.
+- Proposal includes explanation and validation status.
+- Proposal shows constraints checked.
+- User can open diff preview.
+- User can apply the proposal.
+- Applied focus block appears on the calendar.
+- Audit log entry is created.
+- Success banner includes Undo and View audit log.
+- User can undo the apply if no external conflict exists.
+- Undo blocked state is clear when external ETag changed.
+- Invalid proposal does not show actionable Apply.
+- Reject flow captures structured reason and optional free text.
+- No LLM key is required for first aha.
+- UX test passes: user can explain what will change before applying.
+- `go test ./...` passes.
+- Frontend build/test passes using project-standard commands.
+
+---
+
+## 16. Risks and mitigations
+
+| Risk | Impact | Mitigation |
+|---|---:|---|
+| First aha feels too small | Medium | Make trust visible: why, validation, diff, undo |
+| UI overexplains | Medium | Default concise card; technical details expandable |
+| Apply race causes failure | Medium | Treat stale proposal as expected state with regenerate CTA |
+| Undo blocked surprises user | Medium | Explain external changes and link to audit log |
+| Agenda UI becomes scope creep | High | No drag/drop; no week view; Today only |
+| No-slot state feels like failure | Low | Explain blockers and suggest retry/edit preferences later |
+
+---
+
+## 17. Open questions
+
+- Should the first focus block default to 90 minutes or 2 hours?
+- Should `Deep Work` title be configurable before apply or fixed for MVP?
+- Should focus blocks use a dedicated calendar if one exists?
+- Should the UI auto-generate a proposal on page load or require `Find focus slot` click?
+- Should success banner persist until dismissed or disappear after navigation?
+
+---
+
+## 18. Suggested GitHub issue breakdown
+
+1. `feat(api): add today dashboard endpoint`
+2. `feat(web): add Today dashboard route`
+3. `feat(web): add agenda timeline component`
+4. `feat(web): add sync status and availability summaries`
+5. `feat(web): add proposal card with explanation and validation`
+6. `feat(web): add diff preview drawer`
+7. `feat(web): add apply proposal flow`
+8. `feat(web): add undo rollback banner`
+9. `feat(web): add rejection reason dialog`
+10. `test(web): add first-aha happy path and error state tests`
+11. `docs(ux): document first aha flow`

--- a/docs/prp/planning-safety-diff-audit-rollback.md
+++ b/docs/prp/planning-safety-diff-audit-rollback.md
@@ -38,7 +38,7 @@ Calendar-app cannot safely let AI or planning logic edit a calendar until every 
 - Define stable domain models for proposals, diffs, validation, audit, and rollback.
 - Add a deterministic/mock daily planning endpoint that returns one validated proposal.
 - Store proposals with expiration, affected event ETag references, and validation results.
-- Ensure invalid proposals cannot be applied.
+- Ensure invalid, expired, stale, or unsupported proposals cannot be applied.
 - Revalidate constraints and ETags immediately before apply.
 - Apply event changes through the repository layer.
 - Write audit log entries with rollback payloads.
@@ -58,6 +58,7 @@ Calendar-app cannot safely let AI or planning logic edit a calendar until every 
 - No iTIP scheduling.
 - No team scheduling.
 - No broad preference learning beyond minimal focus protection metadata.
+- No implementation of `todoist_update` or `message_draft` apply behavior in MVP.
 
 ---
 
@@ -92,6 +93,7 @@ type PlanProposal struct {
     Changes          []ProposedChange
     ValidationResult ValidationResult
     AffectedRefs     []AffectedEntityRef
+    CanApply         bool
     ExpiresAt        time.Time
     CreatedAt        time.Time
     UpdatedAt        time.Time
@@ -120,12 +122,12 @@ type ValidationResult struct {
 }
 
 type Violation struct {
-    Type               ViolationType
-    Severity           string
-    Message            string
-    ProposedChangeID   string
+    Type                ViolationType
+    Severity            string
+    Message             string
+    ProposedChangeID    string
     ConflictingEntityID string
-    ConflictingUID     string
+    ConflictingUID      string
 }
 
 type RollbackPayload struct {
@@ -135,27 +137,42 @@ type RollbackPayload struct {
     AffectedRefsAtApply []AffectedEntityRef
     CreatedAt           time.Time
 }
-
-type AuditLogEntry struct {
-    ID                   int64
-    UserID               int64
-    Action               string
-    ProposalID           string
-    Summary              string
-    Changes              []ProposedChange
-    RollbackPayload      *RollbackPayload
-    Result               string
-    ErrorCode            string
-    RedactedErrorMessage string
-    CreatedAt            time.Time
-}
 ```
 
-### FR2 - Diff format
+### FR2 - Proposal status lifecycle
+
+Canonical `ProposalStatus` values:
+
+- `draft`: proposal is being assembled and is not visible/actionable.
+- `validated`: proposal passed validation and may be actionable if `can_apply=true`.
+- `invalid`: proposal failed validation before display and cannot be applied.
+- `expired`: proposal can no longer be applied because its time-based expiration passed.
+- `stale`: proposal can no longer be applied because affected calendar state changed since proposal generation, such as changed ETags or deleted affected events.
+- `applied`: proposal was successfully applied.
+- `rejected`: user rejected the proposal.
+- `apply_failed`: apply was attempted but failed for a non-stale reason.
+- `rolled_back`: applied proposal was successfully rolled back.
+- `rollback_blocked`: rollback was attempted but blocked, usually because affected event ETags changed after apply.
+
+Status transition rules:
+
+- Validation failed before display -> `invalid`.
+- Expired due to time -> `expired`.
+- Calendar changed / ETag mismatch / affected event deleted before apply -> `stale`.
+- Apply attempted but failed for non-stale reason -> `apply_failed`.
+- Rollback conflict after external event change -> `rollback_blocked`.
+
+Suggested user-facing stale copy:
+
+```text
+Calendar changed. Regenerate before applying.
+```
+
+### FR3 - Diff format and supported change types
 
 Every proposal must expose machine-readable and human-readable diffs.
 
-Supported change types:
+Schema change types:
 
 - `add`
 - `move`
@@ -164,55 +181,30 @@ Supported change types:
 - `todoist_update` placeholder
 - `message_draft` placeholder
 
-For MVP, only `add` focus block must be fully applied. Other change types may validate/render but return `not_implemented` if applied. The deterministic mock should initially use only `add`.
+MVP support:
 
-Example:
+- MVP apply supports only `add` of a calendar event for a protected focus block.
+- `move`, `delete`, and `update` are schema-ready but not MVP-supported for apply unless a later implementation issue explicitly adds support and tests.
+- `todoist_update` and `message_draft` are placeholders for future compatibility and are not MVP-supported.
 
-```json
-{
-  "changes": [
-    {
-      "id": "chg_01",
-      "type": "add",
-      "entity_type": "event",
-      "human_summary": "+ Add focus block: Deep Work, 09:30-11:30",
-      "after": {
-        "uid": "focus-20260425-0930",
-        "summary": "Deep Work",
-        "start_time": "2026-04-25T09:30:00-04:00",
-        "end_time": "2026-04-25T11:30:00-04:00",
-        "calendar_id": 1,
-        "event_kind": "focus_block",
-        "protection_level": "protected"
-      },
-      "reason": "Longest open morning slot inside working hours"
-    }
-  ]
-}
-```
+Unsupported placeholder or schema-only change types must produce:
 
-### FR3 - Constraint engine
+- `can_apply=false`
+- `validation_result.valid=false`
+- `error_code=unsupported_change_type`
+
+### FR4 - Constraint engine
 
 Implement constraints:
 
-1. `TimeConflictConstraint`
-   - No proposed add/move may overlap fixed confirmed events.
-2. `TimeWindowConstraint`
-   - Proposed focus block must fit configured working hours.
-   - Default window: 09:00-17:00 local time.
-3. `ImmovableEventConstraint`
-   - Proposed move/delete/update cannot affect events tagged immovable.
-   - Proposed add cannot overlap an immovable event.
-4. `FocusBlockProtectionConstraint`
-   - Proposed changes must not weaken or overlap protected focus blocks. For this PRP, block overlaps with protected focus blocks.
-5. `MinimumFocusDurationConstraint`
-   - Focus block must meet default minimum duration, initially 60 minutes unless preference exists.
+1. `TimeConflictConstraint`: no proposed add/move may overlap fixed confirmed events.
+2. `TimeWindowConstraint`: proposed focus block must fit configured working hours; default 09:00-17:00 local time.
+3. `ImmovableEventConstraint`: proposed add cannot overlap an immovable event; future move/delete/update cannot affect immovable events.
+4. `FocusBlockProtectionConstraint`: proposed changes must not weaken or overlap protected focus blocks.
+5. `MinimumFocusDurationConstraint`: focus block must meet default minimum duration, initially 60 minutes unless preference exists.
+6. `SupportedChangeTypeConstraint`: unsupported change types make the proposal invalid and non-actionable.
 
-Validation must happen:
-
-- Before proposal response is returned.
-- Immediately before apply.
-- Immediately before rollback where relevant.
+Validation must happen before proposal response, immediately before apply, and immediately before rollback where relevant.
 
 Invalid proposal behavior:
 
@@ -220,7 +212,7 @@ Invalid proposal behavior:
 - UI must not show actionable Apply for invalid proposal.
 - Apply endpoint must reject invalid proposals regardless of UI behavior.
 
-### FR4 - Proposal storage
+### FR5 - Proposal storage
 
 Persist proposals long enough to apply or expire.
 
@@ -228,12 +220,12 @@ Requirements:
 
 - Store proposal as JSON and normalized metadata.
 - Default expiration: 15 minutes.
-- Store status: `draft`, `validated`, `invalid`, `expired`, `applied`, `rejected`, `apply_failed`, `rolled_back`, `rollback_blocked`.
+- Store canonical status from FR2.
 - Store affected event refs: `calendar_id`, `uid`, `etag_at_generation`, `start_time`, `end_time`.
-- Expired proposals cannot apply.
-- If affected ETags differ at apply time, proposal is stale.
+- Expired proposals cannot apply and transition to `expired`.
+- If affected ETags differ at apply time, proposal transitions to `stale`.
 
-### FR5 - Deterministic daily proposal
+### FR6 - Deterministic daily proposal
 
 Implement:
 
@@ -249,7 +241,7 @@ Behavior:
 - Returns `proposal_id`, `summary`, `explanation`, `changes`, `validation_result`, `can_apply`, and `expires_at`.
 - No LLM required.
 
-### FR6 - Proposal retrieval
+### FR7 - Proposal retrieval
 
 Implement:
 
@@ -257,9 +249,9 @@ Implement:
 GET /api/v1/plan/proposals/{proposal_id}
 ```
 
-Returns stored proposal, current status, validation result, expiration, and can-apply state.
+Returns stored proposal, current status, validation result, expiration, and `can_apply` state.
 
-### FR7 - Apply endpoint
+### FR8 - Apply endpoint
 
 Implement:
 
@@ -280,27 +272,79 @@ Apply behavior:
 
 1. Load proposal.
 2. Reject if not found.
-3. Reject if expired.
+3. Reject if expired; transition proposal to `expired`.
 4. Reject if already applied/rolled back/rejected.
-5. Re-read affected events.
-6. Compare current ETags to stored `etag_at_generation`.
-7. Re-run constraints on current calendar state.
-8. If invalid, return violations and set proposal status `apply_failed` or `stale`.
-9. Begin transaction.
-10. Apply supported changes through repository layer.
-11. Store rollback payload.
-12. Write audit log entry.
-13. Mark proposal `applied`.
-14. Commit transaction.
-15. Return applied summary.
+5. Reject if `can_apply=false`.
+6. Re-read affected events.
+7. Compare current ETags to stored `etag_at_generation`.
+8. If affected calendar state changed, transition proposal to `stale` and return `error_code=stale_proposal`.
+9. Re-run constraints on current calendar state.
+10. If validation fails, transition proposal to `apply_failed` or `stale` depending on cause.
+11. Begin transaction.
+12. Apply supported changes through repository layer.
+13. Store rollback payload.
+14. Write audit log entry.
+15. Mark proposal `applied`.
+16. Commit transaction.
+17. Return applied summary.
 
 Avoid partial apply:
 
 - All supported event changes must be applied in one transaction.
 - If any change fails, rollback the transaction.
-- Future external integrations should use a separate saga/compensation design; out of scope here.
+- Future external integrations should use a separate compensation design; out of scope here.
 
-### FR8 - Rollback endpoint
+Required apply success response:
+
+```json
+{
+  "status": "applied",
+  "proposal_id": "prop_123",
+  "audit_log_entry_id": 42,
+  "rollback_available": true,
+  "can_apply": false,
+  "summary": "Focus block added",
+  "applied_changes": [
+    {
+      "change_id": "change_1",
+      "type": "add",
+      "target_type": "calendar_event",
+      "title": "Deep Work",
+      "start": "2026-04-28T09:30:00-04:00",
+      "end": "2026-04-28T11:30:00-04:00"
+    }
+  ]
+}
+```
+
+Required stale failure response:
+
+```json
+{
+  "status": "stale",
+  "proposal_id": "prop_123",
+  "error_code": "stale_proposal",
+  "message": "Calendar changed. Regenerate before applying.",
+  "can_apply": false,
+  "rollback_available": false,
+  "summary": "Proposal is stale",
+  "applied_changes": []
+}
+```
+
+Required apply response fields:
+
+- `status`.
+- `proposal_id`.
+- `audit_log_entry_id` when apply succeeds.
+- `rollback_available`.
+- `summary`.
+- `applied_changes`.
+- `can_apply`.
+- `error_code` on failure.
+- `message` on failure.
+
+### FR9 - Rollback endpoint
 
 Implement:
 
@@ -311,17 +355,13 @@ POST /api/v1/plan/rollback
 Request options:
 
 ```json
-{
-  "proposal_id": "prop_123"
-}
+{ "proposal_id": "prop_123" }
 ```
 
 or:
 
 ```json
-{
-  "audit_log_entry_id": 42
-}
+{ "audit_log_entry_id": 42 }
 ```
 
 Rollback behavior:
@@ -329,34 +369,20 @@ Rollback behavior:
 1. Load applied audit entry and rollback payload.
 2. Re-read all affected current events.
 3. Compare current ETags to `AffectedRefsAtApply`.
-4. If any ETag changed externally, block rollback.
+4. If any ETag changed externally, block rollback with `error_code=rollback_conflict`.
 5. Explain which event changed and why rollback is blocked.
 6. If safe, begin transaction.
-7. Undo applied changes:
-   - Added event -> delete event.
-   - Moved event -> restore previous start/end/ICS.
-   - Updated event -> restore previous snapshot.
-   - Deleted event -> recreate previous event.
+7. Undo applied changes. MVP supports undo for added focus-block event by deleting that event.
 8. Write rollback audit log entry.
 9. Mark original proposal `rolled_back`.
 10. Commit transaction.
 11. Return rollback summary.
 
-### FR9 - Audit log
+### FR10 - Audit log and rollback payload privacy
 
 Extend existing `audit_log` model if needed.
 
-Audit entries must include:
-
-- User ID.
-- Action.
-- Proposal ID.
-- Human summary.
-- Machine-readable changes.
-- Rollback payload.
-- Result.
-- Created timestamp.
-- Redacted errors.
+Audit entries must include user ID, action, proposal ID, human summary, machine-readable changes, rollback payload reference, result, created timestamp, and redacted errors.
 
 Expose:
 
@@ -365,7 +391,18 @@ GET /api/v1/audit-log
 GET /api/v1/audit-log/{entry_id}
 ```
 
-### FR10 - Rejection endpoint
+MVP rollback payload storage decision:
+
+Rollback payloads may store full event snapshots internally in SQLite for MVP because Calendar-app is self-hosted and rollback requires faithful restoration.
+
+However:
+
+- rollback payloads must not be returned by default API responses;
+- rollback payloads must not be included in default debug bundles;
+- audit log views must show redacted summaries by default;
+- future encryption-at-rest can be considered post-MVP.
+
+### FR11 - Rejection endpoint
 
 Needed by the First Aha UX PRP, but can be backend-ready here:
 
@@ -382,14 +419,20 @@ Request:
 }
 ```
 
-Supported reason codes:
+Supported reason codes: `bad_time`, `too_long`, `too_short`, `conflicts_with_preference`, `not_enough_context`, `other`.
 
-- `bad_time`
-- `too_long`
-- `too_short`
-- `conflicts_with_preference`
-- `not_enough_context`
-- `other`
+### FR12 - Error codes
+
+Use these error codes consistently in API responses, tests, and UX mapping:
+
+- `proposal_expired`
+- `stale_proposal`
+- `validation_failed`
+- `unsupported_change_type`
+- `rollback_conflict`
+- `sync_unhealthy`
+- `apply_failed`
+- `rollback_failed`
 
 ---
 
@@ -398,7 +441,7 @@ Supported reason codes:
 - Determinism: same calendar state + same preferences = same mock proposal.
 - Safety: apply always revalidates.
 - Atomicity: calendar mutations and audit write happen in the same DB transaction where possible.
-- Privacy: audit entries and diffs should avoid raw ICS in default API responses; raw snapshots may be stored for rollback but not exposed by default.
+- Privacy: audit entries and diffs avoid raw ICS in default API responses; full event snapshots may be stored internally for rollback but not exposed by default.
 - Latency: deterministic daily proposal should return under 500ms for typical single-user calendars.
 - Reliability: stale proposals must never apply.
 - Testability: constraint engine must be unit-testable without HTTP server.
@@ -420,6 +463,7 @@ server/internal/planner
   time_window.go
   immovable.go
   focus_protection.go
+  supported_change_type.go
   slot_finder.go
   proposal_service.go
   apply_service.go
@@ -434,45 +478,24 @@ server/internal/data
   sqlite_audit_log_repo.go
 ```
 
-Service interfaces:
-
-```go
-type ProposalService interface {
-    GenerateDaily(ctx context.Context, userID int64, date time.Time) (*PlanProposal, error)
-    Get(ctx context.Context, userID int64, proposalID string) (*PlanProposal, error)
-    Reject(ctx context.Context, userID int64, proposalID string, reason RejectionReason) error
-}
-
-type ApplyService interface {
-    Apply(ctx context.Context, userID int64, proposalID string) (*ApplyResult, error)
-}
-
-type RollbackService interface {
-    Rollback(ctx context.Context, userID int64, req RollbackRequest) (*RollbackResult, error)
-}
-
-type ConstraintEngine interface {
-    Validate(ctx context.Context, proposal *PlanProposal, state CalendarState) (*ValidationResult, error)
-}
-```
-
 ### Validation flow
 
 ```text
 Generate candidate
 -> Build CalendarState from EventRepo
--> Validate constraints
+-> Validate constraints including supported change types
 -> Store proposal with validation result and affected refs
--> Return proposal with can_apply = validation.valid && not expired
+-> Return proposal with can_apply = validation.valid && status == validated && not expired
 ```
 
 ### Apply flow
 
 ```text
 Load proposal
--> Check status/expiration
+-> Check status/expiration/can_apply
 -> Re-read affected events
 -> Check generation ETags
+-> If changed, mark stale and return stale_proposal
 -> Rebuild CalendarState
 -> Revalidate constraints
 -> Begin transaction
@@ -481,6 +504,7 @@ Load proposal
 -> Write audit log
 -> Mark proposal applied
 -> Commit
+-> Return audit_log_entry_id and rollback_available
 ```
 
 ### Rollback flow
@@ -510,6 +534,7 @@ server/internal/planner/time_conflict.go
 server/internal/planner/time_window.go
 server/internal/planner/immovable.go
 server/internal/planner/focus_protection.go
+server/internal/planner/supported_change_type.go
 server/internal/planner/slot_finder.go
 server/internal/planner/proposal_service.go
 server/internal/planner/apply_service.go
@@ -554,21 +579,27 @@ GET  /api/v1/audit-log
 GET  /api/v1/audit-log/{entry_id}
 ```
 
-Common error response:
+Common stale error response:
 
 ```json
 {
-  "error": "stale_proposal",
-  "message": "This proposal is stale because the calendar changed after it was generated.",
-  "details": {
-    "proposal_id": "prop_123",
-    "changed_refs": [
-      {
-        "uid": "event_hash_or_uid",
-        "reason": "etag_changed"
-      }
-    ]
-  }
+  "status": "stale",
+  "proposal_id": "prop_123",
+  "error_code": "stale_proposal",
+  "message": "Calendar changed. Regenerate before applying.",
+  "can_apply": false
+}
+```
+
+Unsupported change type response:
+
+```json
+{
+  "status": "invalid",
+  "proposal_id": "prop_123",
+  "error_code": "unsupported_change_type",
+  "message": "This proposal includes a change type that is not supported by MVP apply.",
+  "can_apply": false
 }
 ```
 
@@ -583,7 +614,10 @@ CREATE TABLE plan_proposals (
   id TEXT PRIMARY KEY,
   user_id INTEGER NOT NULL,
   date DATE NOT NULL,
-  status TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN (
+    'draft', 'validated', 'invalid', 'expired', 'stale', 'applied',
+    'rejected', 'apply_failed', 'rolled_back', 'rollback_blocked'
+  )),
   source TEXT NOT NULL,
   summary TEXT,
   explanation TEXT,
@@ -625,15 +659,16 @@ ALTER TABLE audit_log ADD COLUMN redacted_error_message TEXT;
 
 ## 12. UX changes, if applicable
 
-Backend-only PRP, but API must support future UI:
+Backend-focused PRP, but API must support future UI:
 
 - `can_apply` boolean.
 - `validation_result.valid`.
 - `validation_result.violations`.
-- Grouped diffs by change type.
-- Rollback availability.
-- Rollback conflict explanation.
-- Audit log links.
+- grouped diffs by change type.
+- `audit_log_entry_id` on successful apply.
+- `rollback_available` on apply response.
+- rollback conflict explanation.
+- stale proposal copy: `Calendar changed. Regenerate before applying.`
 
 ---
 
@@ -649,6 +684,7 @@ Constraint tests:
 - `TestImmovableConstraint_BlocksMove`.
 - `TestFocusProtectionConstraint_BlocksOverlap`.
 - `TestMinimumFocusDurationConstraint_BlocksTooShort`.
+- `TestSupportedChangeTypeConstraint_BlocksUnsupportedTypes`.
 
 Proposal tests:
 
@@ -656,31 +692,41 @@ Proposal tests:
 - `TestPlanDaily_ReturnsInvalidWhenNoSafeSlot`.
 - `TestProposalExpires`.
 - `TestStoredProposalIncludesAffectedETags`.
+- `TestUnsupportedChangeTypeReturnsCanApplyFalse`.
 
 Apply tests:
 
 - `TestApply_RevalidatesBeforeWrite`.
 - `TestApply_RejectsInvalidProposal`.
-- `TestApply_RejectsExpiredProposal`.
-- `TestApply_RejectsStaleETag`.
+- `TestApply_RejectsExpiredProposalAndMarksExpired`.
+- `TestApply_RejectsStaleETagAndMarksStale`.
+- `TestApply_RejectsUnsupportedChangeType`.
 - `TestApply_WritesEventViaRepository`.
 - `TestApply_WritesAuditLog`.
+- `TestApply_ReturnsAuditLogEntryID`.
+- `TestApply_ReturnsRollbackAvailable`.
 - `TestApply_StoresRollbackPayload`.
 - `TestApply_TransactionRollbackOnFailure`.
 
 Rollback tests:
 
 - `TestRollback_DeletesAddedFocusBlock`.
-- `TestRollback_RestoresMovedEvent`.
 - `TestRollback_BlocksWhenExternalETagChanged`.
 - `TestRollback_WritesAuditLogEntry`.
 - `TestRollback_CannotRollbackTwice`.
+
+API redaction tests:
+
+- Audit log API responses do not include raw ICS by default.
+- Audit log API responses show human-readable summaries and redacted metadata only.
+- Rollback payload event snapshots remain internal unless explicitly requested through a future authenticated diagnostic path.
 
 API tests:
 
 - `TestPostPlanDaily`.
 - `TestGetProposal`.
-- `TestPostApply`.
+- `TestPostApplySuccessResponseShape`.
+- `TestPostApplyStaleFailureResponseShape`.
 - `TestPostRollback`.
 - `TestGetAuditLog`.
 - `TestRejectProposal`.
@@ -693,30 +739,37 @@ API tests:
 2. Start server.
 3. Seed calendar with fixed events at 09:00-09:30 and 12:00-13:00.
 4. Call `POST /api/v1/plan/daily` with today's date.
-5. Confirm response proposes a non-overlapping focus block.
+5. Confirm response proposes a non-overlapping focus block with `can_apply=true`.
 6. Apply proposal.
-7. Confirm event exists in `events`.
-8. Confirm audit entry exists.
-9. Rollback proposal.
-10. Confirm event removed/restored.
-11. Generate another proposal.
-12. Modify affected event externally.
-13. Attempt apply.
-14. Confirm stale proposal error.
-15. Apply a proposal, externally modify focus event, then attempt rollback.
-16. Confirm rollback conflict error.
+7. Confirm response includes `audit_log_entry_id`, `rollback_available`, `summary`, and `applied_changes`.
+8. Confirm event exists in `events`.
+9. Confirm audit entry exists.
+10. Rollback proposal using either `proposal_id` or `audit_log_entry_id`.
+11. Confirm event removed/restored.
+12. Generate another proposal.
+13. Modify affected event externally.
+14. Attempt apply.
+15. Confirm proposal transitions to `stale` and response says `Calendar changed. Regenerate before applying.`
+16. Apply a proposal, externally modify focus event, then attempt rollback.
+17. Confirm rollback conflict error.
 
 ---
 
 ## 15. Acceptance criteria
 
 - `go test ./...` passes.
-- Constraint tests cover overlap, allowed windows, immovable events, and protected focus blocks.
+- Constraint tests cover overlap, allowed windows, immovable events, protected focus blocks, and unsupported change types.
 - `/api/v1/plan/daily` can return a deterministic/mock validated proposal.
 - Proposal includes machine-readable changes and human-readable diff summaries.
 - Invalid proposals return violations and cannot be applied.
+- Unsupported placeholder change types return `can_apply=false`, `validation_result.valid=false`, and `error_code=unsupported_change_type`.
 - `/api/v1/plan/apply` revalidates before write.
 - Apply checks affected event ETags against proposal generation refs.
+- Stale ETag apply attempts transition the proposal to `stale`.
+- Stale proposals cannot be applied.
+- Stale proposals return a user-facing error instructing the user to regenerate the proposal.
+- Apply success response includes `status`, `proposal_id`, `audit_log_entry_id`, `rollback_available`, `summary`, `applied_changes`, and `can_apply`.
+- Apply failure response includes `status`, `proposal_id`, `error_code`, `message`, and `can_apply=false`.
 - Apply writes event changes via repository layer.
 - Apply writes audit log entry.
 - Apply stores rollback payload.
@@ -725,6 +778,7 @@ API tests:
 - Tests prove stale proposals cannot apply.
 - Tests prove no overlapping focus block can be applied over fixed events.
 - Todoist update and message draft are represented as placeholder diff types but not executed.
+- Audit log API responses do not expose raw ICS by default.
 
 ---
 
@@ -734,8 +788,9 @@ API tests:
 |---|---:|---|
 | Rollback corrupts calendar after external edit | Critical | ETag-at-apply checks before rollback |
 | Apply partially succeeds | High | DB transactions for event changes + audit |
-| Diff schema too narrow for future LLMs | Medium | Include add/move/delete/update/placeholders now |
+| Diff schema too narrow for future LLMs | Medium | Include add/move/delete/update/placeholders now, but block unsupported apply |
 | Audit log stores too much private detail | Medium | Store rollback payload internally; redact API responses |
+| Rollback event snapshots leak through debug/audit APIs | High | Redaction tests; exclude rollback payloads from default debug bundle |
 | Deterministic slot finder feels weak | Low | PRP goal is safety skeleton, not magic |
 | Recurrence edits explode complexity | High | Do not edit complex recurrence in MVP |
 
@@ -743,23 +798,25 @@ API tests:
 
 ## 17. Open questions
 
-- Should rollback payload store raw ICS encrypted at rest, or rely on DB file ownership for MVP?
 - Should proposal expiration be 15 minutes or shorter?
 - Should destructive changes require a separate confirm token now, or only when UI implements destructive actions?
 - Should focus blocks live in a dedicated calendar or be tagged events in default calendar?
-- Should audit log expose raw before/after to local admin only, or never by default?
+- Should a future authenticated diagnostic path expose rollback event snapshots, or should they remain internal only?
+- Should future encryption-at-rest be added for rollback payloads post-MVP?
 
 ---
 
 ## 18. Suggested GitHub issue breakdown
 
 1. `feat(planner): add proposal and diff domain types`
-2. `feat(planner): implement constraint engine`
-3. `feat(planner): implement deterministic focus slot finder`
-4. `feat(data): persist plan proposals and rollback payloads`
-5. `feat(api): add daily proposal and proposal retrieval endpoints`
-6. `feat(api): add apply endpoint with revalidation`
-7. `feat(api): add rollback endpoint with ETag conflict checks`
-8. `feat(api): add audit log endpoints`
-9. `test(planner): cover constraints and stale proposal behavior`
-10. `docs(architecture): document planning safety flow`
+2. `feat(planner): implement canonical proposal statuses including stale`
+3. `feat(planner): implement constraint engine`
+4. `feat(planner): implement supported change type validation`
+5. `feat(planner): implement deterministic focus slot finder`
+6. `feat(data): persist plan proposals and rollback payloads`
+7. `feat(api): add daily proposal and proposal retrieval endpoints`
+8. `feat(api): add apply endpoint with revalidation and response contract`
+9. `feat(api): add rollback endpoint with ETag conflict checks`
+10. `feat(api): add audit log endpoints with redacted responses`
+11. `test(planner): cover constraints, unsupported changes, and stale proposal behavior`
+12. `docs(architecture): document planning safety flow`

--- a/docs/prp/planning-safety-diff-audit-rollback.md
+++ b/docs/prp/planning-safety-diff-audit-rollback.md
@@ -1,0 +1,765 @@
+# PRP: Planning Safety Skeleton, Diff, Audit Log, and Rollback
+
+**Type:** Implementation PRP / Product Requirements Prompt  
+**Target Team:** Backend + API + QA  
+**Status:** Proposed  
+**Priority:** MVP safety backbone
+
+---
+
+## 1. Context
+
+Calendar-app's trust loop is:
+
+```text
+Generate proposal -> validate -> show diff -> confirm -> revalidate -> apply -> audit -> rollback
+```
+
+Before connecting real LLMs, Calendar-app needs a deterministic proposal, diff, validation, apply, audit, and rollback path. This PRP expands the existing Phase C planning skeleton into an implementation-ready safety backbone.
+
+Current repo assumptions:
+
+- CalDAV remains source of truth.
+- Event writes must go through repository/CalDAV-compatible persistence.
+- ETags are already part of event storage and conflict handling.
+- The current `audit_log` table exists but may need extension for proposal-specific payloads.
+- No real LLM or Todoist write is required here.
+
+---
+
+## 2. Problem statement
+
+Calendar-app cannot safely let AI or planning logic edit a calendar until every proposed change is typed, validated, previewable, explicitly applied, auditable, and reversible. Without this skeleton, later LLM-generated changes would lack reliable safety rails and the UI could not honestly promise no silent writes.
+
+---
+
+## 3. Goals
+
+- Define stable domain models for proposals, diffs, validation, audit, and rollback.
+- Add a deterministic/mock daily planning endpoint that returns one validated proposal.
+- Store proposals with expiration, affected event ETag references, and validation results.
+- Ensure invalid proposals cannot be applied.
+- Revalidate constraints and ETags immediately before apply.
+- Apply event changes through the repository layer.
+- Write audit log entries with rollback payloads.
+- Implement conflict-aware rollback.
+- Avoid partial apply whenever possible with transactions.
+
+---
+
+## 4. Non-goals
+
+- No real LLM integration.
+- No Todoist write integration.
+- No auto-apply.
+- No chat planning.
+- No advanced recurrence edits.
+- No message sending.
+- No iTIP scheduling.
+- No team scheduling.
+- No broad preference learning beyond minimal focus protection metadata.
+
+---
+
+## 5. User stories
+
+1. As a user, I can request a daily plan and receive a validated proposal with a clear diff.
+2. As a user, I cannot apply a proposal that overlaps an immovable event or violates focus protection.
+3. As a user, if my calendar changes after preview, apply is blocked and I am told to regenerate.
+4. As a user, every applied proposal appears in the audit log with what changed and why.
+5. As a user, I can rollback an applied proposal if affected events have not changed externally.
+6. As a user, rollback is blocked with a clear explanation if an external client modified an affected event.
+
+---
+
+## 6. Functional requirements
+
+### FR1 - Planning domain model
+
+Add domain models under `server/internal/planner` or `server/internal/domain`.
+
+Required types:
+
+```go
+type PlanProposal struct {
+    ID               string
+    UserID           int64
+    Date             time.Time
+    Status           ProposalStatus
+    Source           ProposalSource
+    Summary          string
+    Explanation      string
+    Changes          []ProposedChange
+    ValidationResult ValidationResult
+    AffectedRefs     []AffectedEntityRef
+    ExpiresAt        time.Time
+    CreatedAt        time.Time
+    UpdatedAt        time.Time
+}
+
+type ProposedChange struct {
+    ID                    string
+    Type                  ChangeType
+    EntityType            EntityType
+    EntityID              string
+    CalendarID            int64
+    UID                   string
+    Before                *ChangeSnapshot
+    After                 *ChangeSnapshot
+    HumanSummary          string
+    Reason                string
+    IsDestructive         bool
+    RequiresStrongConfirm bool
+}
+
+type ValidationResult struct {
+    Valid      bool
+    CheckedAt  time.Time
+    Violations []Violation
+    Warnings   []ValidationWarning
+}
+
+type Violation struct {
+    Type               ViolationType
+    Severity           string
+    Message            string
+    ProposedChangeID   string
+    ConflictingEntityID string
+    ConflictingUID     string
+}
+
+type RollbackPayload struct {
+    ProposalID          string
+    AuditLogEntryID     int64
+    ChangesToUndo       []RollbackChange
+    AffectedRefsAtApply []AffectedEntityRef
+    CreatedAt           time.Time
+}
+
+type AuditLogEntry struct {
+    ID                   int64
+    UserID               int64
+    Action               string
+    ProposalID           string
+    Summary              string
+    Changes              []ProposedChange
+    RollbackPayload      *RollbackPayload
+    Result               string
+    ErrorCode            string
+    RedactedErrorMessage string
+    CreatedAt            time.Time
+}
+```
+
+### FR2 - Diff format
+
+Every proposal must expose machine-readable and human-readable diffs.
+
+Supported change types:
+
+- `add`
+- `move`
+- `delete`
+- `update`
+- `todoist_update` placeholder
+- `message_draft` placeholder
+
+For MVP, only `add` focus block must be fully applied. Other change types may validate/render but return `not_implemented` if applied. The deterministic mock should initially use only `add`.
+
+Example:
+
+```json
+{
+  "changes": [
+    {
+      "id": "chg_01",
+      "type": "add",
+      "entity_type": "event",
+      "human_summary": "+ Add focus block: Deep Work, 09:30-11:30",
+      "after": {
+        "uid": "focus-20260425-0930",
+        "summary": "Deep Work",
+        "start_time": "2026-04-25T09:30:00-04:00",
+        "end_time": "2026-04-25T11:30:00-04:00",
+        "calendar_id": 1,
+        "event_kind": "focus_block",
+        "protection_level": "protected"
+      },
+      "reason": "Longest open morning slot inside working hours"
+    }
+  ]
+}
+```
+
+### FR3 - Constraint engine
+
+Implement constraints:
+
+1. `TimeConflictConstraint`
+   - No proposed add/move may overlap fixed confirmed events.
+2. `TimeWindowConstraint`
+   - Proposed focus block must fit configured working hours.
+   - Default window: 09:00-17:00 local time.
+3. `ImmovableEventConstraint`
+   - Proposed move/delete/update cannot affect events tagged immovable.
+   - Proposed add cannot overlap an immovable event.
+4. `FocusBlockProtectionConstraint`
+   - Proposed changes must not weaken or overlap protected focus blocks. For this PRP, block overlaps with protected focus blocks.
+5. `MinimumFocusDurationConstraint`
+   - Focus block must meet default minimum duration, initially 60 minutes unless preference exists.
+
+Validation must happen:
+
+- Before proposal response is returned.
+- Immediately before apply.
+- Immediately before rollback where relevant.
+
+Invalid proposal behavior:
+
+- API may return invalid proposal with violations for debugging, but `can_apply=false`.
+- UI must not show actionable Apply for invalid proposal.
+- Apply endpoint must reject invalid proposals regardless of UI behavior.
+
+### FR4 - Proposal storage
+
+Persist proposals long enough to apply or expire.
+
+Requirements:
+
+- Store proposal as JSON and normalized metadata.
+- Default expiration: 15 minutes.
+- Store status: `draft`, `validated`, `invalid`, `expired`, `applied`, `rejected`, `apply_failed`, `rolled_back`, `rollback_blocked`.
+- Store affected event refs: `calendar_id`, `uid`, `etag_at_generation`, `start_time`, `end_time`.
+- Expired proposals cannot apply.
+- If affected ETags differ at apply time, proposal is stale.
+
+### FR5 - Deterministic daily proposal
+
+Implement:
+
+```http
+POST /api/v1/plan/daily
+```
+
+Behavior:
+
+- Reads today's existing events.
+- Finds the first or best safe focus block slot using deterministic rules.
+- Default target: 2-hour block preferred, 60-minute minimum, within working hours, no overlaps, prefer morning slot.
+- Returns `proposal_id`, `summary`, `explanation`, `changes`, `validation_result`, `can_apply`, and `expires_at`.
+- No LLM required.
+
+### FR6 - Proposal retrieval
+
+Implement:
+
+```http
+GET /api/v1/plan/proposals/{proposal_id}
+```
+
+Returns stored proposal, current status, validation result, expiration, and can-apply state.
+
+### FR7 - Apply endpoint
+
+Implement:
+
+```http
+POST /api/v1/plan/apply
+```
+
+Request:
+
+```json
+{
+  "proposal_id": "prop_123",
+  "confirm_token": "optional-for-future"
+}
+```
+
+Apply behavior:
+
+1. Load proposal.
+2. Reject if not found.
+3. Reject if expired.
+4. Reject if already applied/rolled back/rejected.
+5. Re-read affected events.
+6. Compare current ETags to stored `etag_at_generation`.
+7. Re-run constraints on current calendar state.
+8. If invalid, return violations and set proposal status `apply_failed` or `stale`.
+9. Begin transaction.
+10. Apply supported changes through repository layer.
+11. Store rollback payload.
+12. Write audit log entry.
+13. Mark proposal `applied`.
+14. Commit transaction.
+15. Return applied summary.
+
+Avoid partial apply:
+
+- All supported event changes must be applied in one transaction.
+- If any change fails, rollback the transaction.
+- Future external integrations should use a separate saga/compensation design; out of scope here.
+
+### FR8 - Rollback endpoint
+
+Implement:
+
+```http
+POST /api/v1/plan/rollback
+```
+
+Request options:
+
+```json
+{
+  "proposal_id": "prop_123"
+}
+```
+
+or:
+
+```json
+{
+  "audit_log_entry_id": 42
+}
+```
+
+Rollback behavior:
+
+1. Load applied audit entry and rollback payload.
+2. Re-read all affected current events.
+3. Compare current ETags to `AffectedRefsAtApply`.
+4. If any ETag changed externally, block rollback.
+5. Explain which event changed and why rollback is blocked.
+6. If safe, begin transaction.
+7. Undo applied changes:
+   - Added event -> delete event.
+   - Moved event -> restore previous start/end/ICS.
+   - Updated event -> restore previous snapshot.
+   - Deleted event -> recreate previous event.
+8. Write rollback audit log entry.
+9. Mark original proposal `rolled_back`.
+10. Commit transaction.
+11. Return rollback summary.
+
+### FR9 - Audit log
+
+Extend existing `audit_log` model if needed.
+
+Audit entries must include:
+
+- User ID.
+- Action.
+- Proposal ID.
+- Human summary.
+- Machine-readable changes.
+- Rollback payload.
+- Result.
+- Created timestamp.
+- Redacted errors.
+
+Expose:
+
+```http
+GET /api/v1/audit-log
+GET /api/v1/audit-log/{entry_id}
+```
+
+### FR10 - Rejection endpoint
+
+Needed by the First Aha UX PRP, but can be backend-ready here:
+
+```http
+POST /api/v1/plan/proposals/{proposal_id}/reject
+```
+
+Request:
+
+```json
+{
+  "reason_code": "bad_time",
+  "free_text": "Too close to lunch"
+}
+```
+
+Supported reason codes:
+
+- `bad_time`
+- `too_long`
+- `too_short`
+- `conflicts_with_preference`
+- `not_enough_context`
+- `other`
+
+---
+
+## 7. Non-functional requirements
+
+- Determinism: same calendar state + same preferences = same mock proposal.
+- Safety: apply always revalidates.
+- Atomicity: calendar mutations and audit write happen in the same DB transaction where possible.
+- Privacy: audit entries and diffs should avoid raw ICS in default API responses; raw snapshots may be stored for rollback but not exposed by default.
+- Latency: deterministic daily proposal should return under 500ms for typical single-user calendars.
+- Reliability: stale proposals must never apply.
+- Testability: constraint engine must be unit-testable without HTTP server.
+- Extensibility: LLM proposal source can later create the same `PlanProposal` format.
+
+---
+
+## 8. Technical approach
+
+### Backend architecture
+
+Suggested packages:
+
+```text
+server/internal/planner
+  types.go
+  constraints.go
+  time_conflict.go
+  time_window.go
+  immovable.go
+  focus_protection.go
+  slot_finder.go
+  proposal_service.go
+  apply_service.go
+  rollback_service.go
+
+server/internal/api
+  plan.go
+  audit_log.go
+
+server/internal/data
+  sqlite_plan_proposal_repo.go
+  sqlite_audit_log_repo.go
+```
+
+Service interfaces:
+
+```go
+type ProposalService interface {
+    GenerateDaily(ctx context.Context, userID int64, date time.Time) (*PlanProposal, error)
+    Get(ctx context.Context, userID int64, proposalID string) (*PlanProposal, error)
+    Reject(ctx context.Context, userID int64, proposalID string, reason RejectionReason) error
+}
+
+type ApplyService interface {
+    Apply(ctx context.Context, userID int64, proposalID string) (*ApplyResult, error)
+}
+
+type RollbackService interface {
+    Rollback(ctx context.Context, userID int64, req RollbackRequest) (*RollbackResult, error)
+}
+
+type ConstraintEngine interface {
+    Validate(ctx context.Context, proposal *PlanProposal, state CalendarState) (*ValidationResult, error)
+}
+```
+
+### Validation flow
+
+```text
+Generate candidate
+-> Build CalendarState from EventRepo
+-> Validate constraints
+-> Store proposal with validation result and affected refs
+-> Return proposal with can_apply = validation.valid && not expired
+```
+
+### Apply flow
+
+```text
+Load proposal
+-> Check status/expiration
+-> Re-read affected events
+-> Check generation ETags
+-> Rebuild CalendarState
+-> Revalidate constraints
+-> Begin transaction
+-> Apply event changes
+-> Store rollback payload
+-> Write audit log
+-> Mark proposal applied
+-> Commit
+```
+
+### Rollback flow
+
+```text
+Load audit entry
+-> Load rollback payload
+-> Re-read affected events
+-> Compare ETags at apply time
+-> If safe, begin transaction
+-> Undo event changes
+-> Write rollback audit entry
+-> Mark proposal rolled_back
+-> Commit
+```
+
+---
+
+## 9. Files likely to change
+
+Backend:
+
+```text
+server/internal/planner/types.go
+server/internal/planner/constraints.go
+server/internal/planner/time_conflict.go
+server/internal/planner/time_window.go
+server/internal/planner/immovable.go
+server/internal/planner/focus_protection.go
+server/internal/planner/slot_finder.go
+server/internal/planner/proposal_service.go
+server/internal/planner/apply_service.go
+server/internal/planner/rollback_service.go
+server/internal/planner/*_test.go
+server/internal/api/plan.go
+server/internal/api/audit_log.go
+server/internal/api/types.go
+server/internal/data/sqlite_plan_proposal_repo.go
+server/internal/data/sqlite_audit_log_repo.go
+server/internal/domain/event.go
+server/internal/domain/repository.go
+server/migrations/00003_planning_safety.sql
+server/cmd/calendarapp/main.go
+```
+
+Frontend-ready types only:
+
+```text
+web/src/lib/types.ts
+web/src/lib/api.ts
+```
+
+Docs:
+
+```text
+docs/architecture/planning-safety.md
+docs/api/planning.md
+```
+
+---
+
+## 10. API changes
+
+```http
+POST /api/v1/plan/daily
+GET  /api/v1/plan/proposals/{proposal_id}
+POST /api/v1/plan/proposals/{proposal_id}/reject
+POST /api/v1/plan/apply
+POST /api/v1/plan/rollback
+GET  /api/v1/audit-log
+GET  /api/v1/audit-log/{entry_id}
+```
+
+Common error response:
+
+```json
+{
+  "error": "stale_proposal",
+  "message": "This proposal is stale because the calendar changed after it was generated.",
+  "details": {
+    "proposal_id": "prop_123",
+    "changed_refs": [
+      {
+        "uid": "event_hash_or_uid",
+        "reason": "etag_changed"
+      }
+    ]
+  }
+}
+```
+
+---
+
+## 11. Database/schema changes
+
+Create migration `server/migrations/00003_planning_safety.sql`.
+
+```sql
+CREATE TABLE plan_proposals (
+  id TEXT PRIMARY KEY,
+  user_id INTEGER NOT NULL,
+  date DATE NOT NULL,
+  status TEXT NOT NULL,
+  source TEXT NOT NULL,
+  summary TEXT,
+  explanation TEXT,
+  changes_json TEXT NOT NULL,
+  validation_json TEXT NOT NULL,
+  affected_refs_json TEXT NOT NULL,
+  rejection_json TEXT,
+  expires_at DATETIME NOT NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_plan_proposals_user_date ON plan_proposals(user_id, date);
+CREATE INDEX idx_plan_proposals_status ON plan_proposals(status);
+CREATE INDEX idx_plan_proposals_expires_at ON plan_proposals(expires_at);
+
+CREATE TABLE rollback_payloads (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER NOT NULL,
+  proposal_id TEXT NOT NULL,
+  audit_log_entry_id INTEGER,
+  payload_json TEXT NOT NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+  FOREIGN KEY (proposal_id) REFERENCES plan_proposals(id) ON DELETE CASCADE,
+  FOREIGN KEY (audit_log_entry_id) REFERENCES audit_log(id) ON DELETE SET NULL
+);
+
+CREATE INDEX idx_rollback_payloads_proposal_id ON rollback_payloads(proposal_id);
+
+ALTER TABLE audit_log ADD COLUMN proposal_id TEXT;
+ALTER TABLE audit_log ADD COLUMN result TEXT;
+ALTER TABLE audit_log ADD COLUMN error_code TEXT;
+ALTER TABLE audit_log ADD COLUMN redacted_error_message TEXT;
+```
+
+---
+
+## 12. UX changes, if applicable
+
+Backend-only PRP, but API must support future UI:
+
+- `can_apply` boolean.
+- `validation_result.valid`.
+- `validation_result.violations`.
+- Grouped diffs by change type.
+- Rollback availability.
+- Rollback conflict explanation.
+- Audit log links.
+
+---
+
+## 13. Test plan
+
+Constraint tests:
+
+- `TestTimeConflictConstraint_NoOverlap`.
+- `TestTimeConflictConstraint_Overlap`.
+- `TestTimeWindowConstraint_InsideWindow`.
+- `TestTimeWindowConstraint_OutsideWindow`.
+- `TestImmovableConstraint_BlocksOverlap`.
+- `TestImmovableConstraint_BlocksMove`.
+- `TestFocusProtectionConstraint_BlocksOverlap`.
+- `TestMinimumFocusDurationConstraint_BlocksTooShort`.
+
+Proposal tests:
+
+- `TestPlanDaily_ReturnsDeterministicProposal`.
+- `TestPlanDaily_ReturnsInvalidWhenNoSafeSlot`.
+- `TestProposalExpires`.
+- `TestStoredProposalIncludesAffectedETags`.
+
+Apply tests:
+
+- `TestApply_RevalidatesBeforeWrite`.
+- `TestApply_RejectsInvalidProposal`.
+- `TestApply_RejectsExpiredProposal`.
+- `TestApply_RejectsStaleETag`.
+- `TestApply_WritesEventViaRepository`.
+- `TestApply_WritesAuditLog`.
+- `TestApply_StoresRollbackPayload`.
+- `TestApply_TransactionRollbackOnFailure`.
+
+Rollback tests:
+
+- `TestRollback_DeletesAddedFocusBlock`.
+- `TestRollback_RestoresMovedEvent`.
+- `TestRollback_BlocksWhenExternalETagChanged`.
+- `TestRollback_WritesAuditLogEntry`.
+- `TestRollback_CannotRollbackTwice`.
+
+API tests:
+
+- `TestPostPlanDaily`.
+- `TestGetProposal`.
+- `TestPostApply`.
+- `TestPostRollback`.
+- `TestGetAuditLog`.
+- `TestRejectProposal`.
+
+---
+
+## 14. Manual validation steps
+
+1. Run `cd server && go test ./...`.
+2. Start server.
+3. Seed calendar with fixed events at 09:00-09:30 and 12:00-13:00.
+4. Call `POST /api/v1/plan/daily` with today's date.
+5. Confirm response proposes a non-overlapping focus block.
+6. Apply proposal.
+7. Confirm event exists in `events`.
+8. Confirm audit entry exists.
+9. Rollback proposal.
+10. Confirm event removed/restored.
+11. Generate another proposal.
+12. Modify affected event externally.
+13. Attempt apply.
+14. Confirm stale proposal error.
+15. Apply a proposal, externally modify focus event, then attempt rollback.
+16. Confirm rollback conflict error.
+
+---
+
+## 15. Acceptance criteria
+
+- `go test ./...` passes.
+- Constraint tests cover overlap, allowed windows, immovable events, and protected focus blocks.
+- `/api/v1/plan/daily` can return a deterministic/mock validated proposal.
+- Proposal includes machine-readable changes and human-readable diff summaries.
+- Invalid proposals return violations and cannot be applied.
+- `/api/v1/plan/apply` revalidates before write.
+- Apply checks affected event ETags against proposal generation refs.
+- Apply writes event changes via repository layer.
+- Apply writes audit log entry.
+- Apply stores rollback payload.
+- Rollback restores original event state when no external conflict exists.
+- Rollback blocks with clear explanation when external ETag changed.
+- Tests prove stale proposals cannot apply.
+- Tests prove no overlapping focus block can be applied over fixed events.
+- Todoist update and message draft are represented as placeholder diff types but not executed.
+
+---
+
+## 16. Risks and mitigations
+
+| Risk | Impact | Mitigation |
+|---|---:|---|
+| Rollback corrupts calendar after external edit | Critical | ETag-at-apply checks before rollback |
+| Apply partially succeeds | High | DB transactions for event changes + audit |
+| Diff schema too narrow for future LLMs | Medium | Include add/move/delete/update/placeholders now |
+| Audit log stores too much private detail | Medium | Store rollback payload internally; redact API responses |
+| Deterministic slot finder feels weak | Low | PRP goal is safety skeleton, not magic |
+| Recurrence edits explode complexity | High | Do not edit complex recurrence in MVP |
+
+---
+
+## 17. Open questions
+
+- Should rollback payload store raw ICS encrypted at rest, or rely on DB file ownership for MVP?
+- Should proposal expiration be 15 minutes or shorter?
+- Should destructive changes require a separate confirm token now, or only when UI implements destructive actions?
+- Should focus blocks live in a dedicated calendar or be tagged events in default calendar?
+- Should audit log expose raw before/after to local admin only, or never by default?
+
+---
+
+## 18. Suggested GitHub issue breakdown
+
+1. `feat(planner): add proposal and diff domain types`
+2. `feat(planner): implement constraint engine`
+3. `feat(planner): implement deterministic focus slot finder`
+4. `feat(data): persist plan proposals and rollback payloads`
+5. `feat(api): add daily proposal and proposal retrieval endpoints`
+6. `feat(api): add apply endpoint with revalidation`
+7. `feat(api): add rollback endpoint with ETag conflict checks`
+8. `feat(api): add audit log endpoints`
+9. `test(planner): cover constraints and stale proposal behavior`
+10. `docs(architecture): document planning safety flow`


### PR DESCRIPTION
## Summary

Adds three implementation-ready PRPs for the next Calendar-app MVP enhancements:

1. **CalDAV Trust, Sync Health, and Interop Gate**
   - CalDAV interop evidence
   - Sync Health dashboard
   - Redacted debug bundle
   - Green-sync onboarding gate

2. **Planning Safety Skeleton, Diff, Audit Log, and Rollback**
   - Plan proposal/diff domain model
   - Constraint validation
   - Apply-time revalidation
   - Audit log and safe rollback

3. **First Aha UX - Agenda, Focus Proposal, Diff Review, and Undo**
   - Today dashboard
   - One safe focus-block proposal
   - Diff preview
   - Apply, undo, reject, and error states

Also adds an overview file with recommended implementation order, dependency map, epic breakdown, cross-PRP risks, and MVP cutline.

## Files added

- `docs/prp/caldav-trust-sync-health-interop-gate.md`
- `docs/prp/planning-safety-diff-audit-rollback.md`
- `docs/prp/first-aha-agenda-focus-diff-undo.md`
- `docs/prp/enhancement-prps-overview.md`

## Validation

- Docs-only change; no code executed.
- Compared branch against `main` and confirmed only the four PRP docs are added.
