### PR TITLE
ci: add Go server tests workflow

### DIFF
--- a/.github/workflows/go-server-tests.yml
+++ b/.github/workflows/go-server-tests.yml
@@ -1,0 +1,26 @@
+name: Go server tests
+
+on:
+  pull_request:
+    paths:
+      - "server/**"
+      - ".github/workflows/go-server-tests.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "server/**"
+      - ".github/workflows/go-server-tests.yml"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: server
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: server/go.mod
+      - run: go test ./...


### PR DESCRIPTION
## Summary

Adds a minimal GitHub Actions workflow to provide a backend test signal for server changes.

## Scope

- Runs `go test ./...` from `server/` on PRs touching `server/**`.
- Runs the same test command on pushes to `main` touching `server/**`.

## Motivation

PR #36 is ready to merge after test confirmation, but this environment cannot perform a normal local checkout because `github.com` DNS resolution fails. Adding this workflow lets GitHub Actions provide the required test signal for PR #36 and future backend PRs.

## Tests

This PR introduces the workflow; validation is the workflow run itself.
