### PR TITLE
Record CalDAV operation metadata

### DIFF
--- a/server/internal/caldav/handler.go
+++ b/server/internal/caldav/handler.go
@@ -47,6 +47,11 @@ func NewHandler() http.Handler {
 // The db parameter is required for transaction support (atomic event write + sync token bump).
 // The calendarRepo and eventRepo must be concrete SQLite repos to support WithTx.
 func NewHandlerWithRepos(db *sql.DB, userRepo domain.UserRepo, calendarRepo *data.SQLiteCalendarRepo, eventRepo *data.SQLiteEventRepo) http.Handler {
+	return NewHandlerWithReposAndOperationRecorder(db, userRepo, calendarRepo, eventRepo, data.NewSQLiteCalDAVOperationRepo(db))
+}
+
+// NewHandlerWithReposAndOperationRecorder creates the real CalDAV handler with optional redacted operation recording.
+func NewHandlerWithReposAndOperationRecorder(db *sql.DB, userRepo domain.UserRepo, calendarRepo *data.SQLiteCalendarRepo, eventRepo *data.SQLiteEventRepo, operationRepo domain.CalDAVOperationRepo) http.Handler {
 	authConfig := LoadAuthConfig()
 
 	backend := NewBackend(db, userRepo, calendarRepo, eventRepo)
@@ -59,6 +64,9 @@ func NewHandlerWithRepos(db *sql.DB, userRepo domain.UserRepo, calendarRepo *dat
 
 	// Create Chi router for CalDAV routes
 	r := chi.NewRouter()
+
+	// Record redacted CalDAV operation metadata before auth so auth failures are visible.
+	r.Use(OperationMetadataMiddleware(operationRepo))
 
 	// Apply Basic Auth middleware
 	r.Use(BasicAuthMiddleware(authConfig, userRepo))

--- a/server/internal/caldav/operation_metadata.go
+++ b/server/internal/caldav/operation_metadata.go
@@ -153,7 +153,6 @@ func BuildCalDAVOperation(method string, rawPath string, statusCode int, duratio
 		PathPattern:       RedactCalDAVPath(rawPath),
 		StatusCode:        statusCode,
 		DurationMillis:    duration.Milliseconds(),
-		ClientUserAgent:   userAgent,
 		ClientFingerprint: NormalizeClientFingerprint(userAgent),
 		ETagOutcome:       etagOutcome,
 		OperationKind:     kind,

--- a/server/internal/caldav/operation_metadata.go
+++ b/server/internal/caldav/operation_metadata.go
@@ -1,0 +1,166 @@
+package caldav
+
+import (
+	"fmt"
+	"net/http"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/airplne/calendar-app/server/internal/domain"
+)
+
+func NormalizeClientFingerprint(userAgent string) string {
+	ua := strings.ToLower(userAgent)
+	switch {
+	case strings.Contains(ua, "fantastical"):
+		return domain.CalDAVClientFantastical
+	case strings.Contains(ua, "davx5") || strings.Contains(ua, "davx⁵"):
+		return domain.CalDAVClientDAVx5
+	case strings.Contains(ua, "thunderbird"):
+		return domain.CalDAVClientThunderbird
+	case strings.Contains(ua, "dataaccess") || strings.Contains(ua, "calendarstore") || strings.Contains(ua, "apple"):
+		return domain.CalDAVClientAppleCalendar
+	default:
+		return domain.CalDAVClientUnknown
+	}
+}
+
+func RedactCalDAVPath(rawPath string) string {
+	if rawPath == "" {
+		return "/"
+	}
+	clean := path.Clean(rawPath)
+	if clean == "/." {
+		clean = "/"
+	}
+	if clean == "/.well-known/caldav" {
+		return "/.well-known/caldav"
+	}
+	if clean == "/dav" || clean == "/dav/" {
+		return "/dav/"
+	}
+
+	parts := strings.Split(strings.Trim(clean, "/"), "/")
+	if len(parts) == 0 || parts[0] == "" {
+		return "/"
+	}
+
+	for i, part := range parts {
+		if part == "calendars" {
+			prefix := ""
+			if i > 0 && parts[0] == "dav" {
+				prefix = "/dav"
+			}
+			if len(parts) == i+1 {
+				return prefix + "/calendars/"
+			}
+			if len(parts) == i+2 {
+				return prefix + "/calendars/{principal}/"
+			}
+			if len(parts) == i+3 {
+				return prefix + "/calendars/{principal}/{calendar}/"
+			}
+			return prefix + "/calendars/{principal}/{calendar}/{object}.ics"
+		}
+		if part == "principals" {
+			prefix := ""
+			if i > 0 && parts[0] == "dav" {
+				prefix = "/dav"
+			}
+			return prefix + "/principals/{principal}/"
+		}
+	}
+
+	if parts[0] == "dav" {
+		return "/dav/{resource}"
+	}
+	return "/{resource}"
+}
+
+func ClassifyOperationKind(method string) domain.CalDAVOperationKind {
+	switch strings.ToUpper(method) {
+	case http.MethodPut, http.MethodDelete, "PROPPATCH", "MKCOL", "MOVE", "COPY", http.MethodPost, http.MethodPatch:
+		return domain.CalDAVOperationWrite
+	default:
+		return domain.CalDAVOperationRead
+	}
+}
+
+func ClassifyETagOutcome(method string, statusCode int, requestHeader http.Header, responseHeader http.Header) domain.CalDAVETagOutcome {
+	if statusCode == http.StatusPreconditionFailed {
+		return domain.CalDAVETagMismatched
+	}
+	if requestHeader.Get("If-Match") != "" {
+		return domain.CalDAVETagMatched
+	}
+	if requestHeader.Get("If-None-Match") != "" {
+		return domain.CalDAVETagMissing
+	}
+	if responseHeader.Get("ETag") != "" {
+		return domain.CalDAVETagGenerated
+	}
+	return domain.CalDAVETagNotApplicable
+}
+
+func ClassifyOperationOutcome(kind domain.CalDAVOperationKind, statusCode int, errCode domain.CalDAVErrorCode) domain.CalDAVOperationOutcome {
+	if statusCode >= 200 && statusCode < 400 && errCode == domain.CalDAVErrorNone {
+		return domain.CalDAVOperationSuccess
+	}
+	if errCode == domain.CalDAVErrorCorruptICS || errCode == domain.CalDAVErrorDuplicateUID || errCode == domain.CalDAVErrorParse {
+		return domain.CalDAVOperationIntegrityFailure
+	}
+	if statusCode >= 500 {
+		return domain.CalDAVOperationIntegrityFailure
+	}
+	return domain.CalDAVOperationRecoverableFailure
+}
+
+func RedactedCalDAVError(statusCode int, method string) (domain.CalDAVErrorCode, string) {
+	if statusCode >= 200 && statusCode < 400 {
+		return domain.CalDAVErrorNone, ""
+	}
+	if statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden {
+		return domain.CalDAVErrorAuthFailed, "Authentication failed."
+	}
+	if statusCode == http.StatusPreconditionFailed {
+		return domain.CalDAVErrorETagConflict, "ETag precondition failed."
+	}
+	if statusCode == http.StatusMethodNotAllowed || statusCode == http.StatusNotImplemented {
+		return domain.CalDAVErrorUnsupportedMethod, "Unsupported CalDAV method."
+	}
+	if statusCode >= 500 {
+		return domain.CalDAVErrorWriteFailed, "CalDAV operation failed."
+	}
+	if strings.EqualFold(method, http.MethodPut) || strings.EqualFold(method, "PROPPATCH") {
+		return domain.CalDAVErrorWriteFailed, "CalDAV write failed."
+	}
+	return domain.CalDAVErrorUnknown, "CalDAV operation failed."
+}
+
+func BuildCalDAVOperation(method string, rawPath string, statusCode int, duration time.Duration, requestHeader http.Header, responseHeader http.Header, userAgent string, requestSize int64, responseSize int64) domain.CalDAVOperation {
+	kind := ClassifyOperationKind(method)
+	errorCode, redactedError := RedactedCalDAVError(statusCode, method)
+	etagOutcome := ClassifyETagOutcome(method, statusCode, requestHeader, responseHeader)
+	if errorCode == domain.CalDAVErrorETagConflict {
+		etagOutcome = domain.CalDAVETagMismatched
+	}
+
+	return domain.CalDAVOperation{
+		ID:                fmt.Sprintf("caldav-%d", time.Now().UnixNano()),
+		OccurredAt:        time.Now().UTC(),
+		Method:            strings.ToUpper(method),
+		PathPattern:       RedactCalDAVPath(rawPath),
+		StatusCode:        statusCode,
+		DurationMillis:    duration.Milliseconds(),
+		ClientUserAgent:   userAgent,
+		ClientFingerprint: NormalizeClientFingerprint(userAgent),
+		ETagOutcome:       etagOutcome,
+		OperationKind:     kind,
+		Outcome:           ClassifyOperationOutcome(kind, statusCode, errorCode),
+		ErrorCode:         errorCode,
+		RedactedError:     redactedError,
+		RequestSizeBytes:  requestSize,
+		ResponseSizeBytes: responseSize,
+	}
+}

--- a/server/internal/caldav/operation_metadata_test.go
+++ b/server/internal/caldav/operation_metadata_test.go
@@ -1,0 +1,183 @@
+package caldav
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/airplne/calendar-app/server/internal/data"
+	"github.com/airplne/calendar-app/server/internal/domain"
+)
+
+func TestNormalizeClientFingerprint(t *testing.T) {
+	tests := []struct {
+		name      string
+		userAgent string
+		want      string
+	}{
+		{name: "apple calendar", userAgent: "Mac+OS+X/14.0 (23A344) CalendarAgent/1000 DataAccess/1", want: domain.CalDAVClientAppleCalendar},
+		{name: "fantastical", userAgent: "Fantastical/4.0 CFNetwork/1490", want: domain.CalDAVClientFantastical},
+		{name: "davx5 ascii", userAgent: "DAVx5/4.4.1-ose (2024/01)", want: domain.CalDAVClientDAVx5},
+		{name: "davx5 superscript", userAgent: "DAVx⁵/4.4.1", want: domain.CalDAVClientDAVx5},
+		{name: "thunderbird", userAgent: "Mozilla/5.0 Thunderbird/115.0", want: domain.CalDAVClientThunderbird},
+		{name: "unknown", userAgent: "CustomSyncClient/1.0", want: domain.CalDAVClientUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NormalizeClientFingerprint(tt.userAgent); got != tt.want {
+				t.Fatalf("NormalizeClientFingerprint() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRedactCalDAVPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "well known", path: "/.well-known/caldav", want: "/.well-known/caldav"},
+		{name: "dav root", path: "/dav/", want: "/dav/"},
+		{name: "calendar collection", path: "/dav/calendars/alice/private-work/", want: "/dav/calendars/{principal}/{calendar}/"},
+		{name: "calendar object", path: "/dav/calendars/alice/private-work/doctor-visit-123.ics", want: "/dav/calendars/{principal}/{calendar}/{object}.ics"},
+		{name: "prefix stripped object", path: "/calendars/alice/private-work/doctor-visit-123.ics", want: "/calendars/{principal}/{calendar}/{object}.ics"},
+		{name: "principal", path: "/dav/principals/alice/", want: "/dav/principals/{principal}/"},
+		{name: "unknown dav resource", path: "/dav/some/private/value", want: "/dav/{resource}"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := RedactCalDAVPath(tt.path); got != tt.want {
+				t.Fatalf("RedactCalDAVPath() = %q, want %q", got, tt.want)
+			}
+			if strings.Contains(got, "alice") || strings.Contains(got, "doctor") || strings.Contains(got, "private-work") {
+				t.Fatalf("redacted path leaked private path data: %q", got)
+			}
+		})
+	}
+}
+
+func TestOperationClassification(t *testing.T) {
+	readOp := BuildCalDAVOperation("GET", "/dav/calendars/user/default/event.ics", http.StatusOK, 10*time.Millisecond, http.Header{}, http.Header{}, "Custom/1", 0, 100)
+	if readOp.OperationKind != domain.CalDAVOperationRead {
+		t.Fatalf("GET kind = %q, want read", readOp.OperationKind)
+	}
+	if readOp.Outcome != domain.CalDAVOperationSuccess {
+		t.Fatalf("GET outcome = %q, want success", readOp.Outcome)
+	}
+
+	writeOp := BuildCalDAVOperation("PUT", "/dav/calendars/user/default/event.ics", http.StatusCreated, 10*time.Millisecond, http.Header{}, http.Header{"ETag": []string{"abc"}}, "Custom/1", 200, 0)
+	if writeOp.OperationKind != domain.CalDAVOperationWrite {
+		t.Fatalf("PUT kind = %q, want write", writeOp.OperationKind)
+	}
+	if writeOp.ETagOutcome != domain.CalDAVETagGenerated {
+		t.Fatalf("PUT ETag outcome = %q, want generated", writeOp.ETagOutcome)
+	}
+
+	conflictOp := BuildCalDAVOperation("PUT", "/dav/calendars/user/default/event.ics", http.StatusPreconditionFailed, 10*time.Millisecond, http.Header{"If-Match": []string{"wrong"}}, http.Header{}, "Custom/1", 200, 0)
+	if conflictOp.Outcome != domain.CalDAVOperationRecoverableFailure {
+		t.Fatalf("412 outcome = %q, want recoverable_failure", conflictOp.Outcome)
+	}
+	if conflictOp.ErrorCode != domain.CalDAVErrorETagConflict {
+		t.Fatalf("412 error = %q, want etag_conflict", conflictOp.ErrorCode)
+	}
+	if conflictOp.ETagOutcome != domain.CalDAVETagMismatched {
+		t.Fatalf("412 ETag outcome = %q, want mismatched", conflictOp.ETagOutcome)
+	}
+
+	parseOp := domain.CalDAVOperation{Outcome: ClassifyOperationOutcome(domain.CalDAVOperationRead, http.StatusBadRequest, domain.CalDAVErrorParse)}
+	if parseOp.Outcome != domain.CalDAVOperationIntegrityFailure {
+		t.Fatalf("parse outcome = %q, want integrity_failure", parseOp.Outcome)
+	}
+}
+
+func TestOperationMetadataMiddlewareRecordsRedactedRequest(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	db, err := data.OpenDB(tmpDir)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+	if err := data.RunMigrations(db, getMigrationsDir(t)); err != nil {
+		t.Fatalf("run migrations: %v", err)
+	}
+
+	userRepo := data.NewSQLiteUserRepo(db)
+	calendarRepo := data.NewSQLiteCalendarRepo(db)
+	eventRepo := data.NewSQLiteEventRepo(db)
+	operationRepo := data.NewSQLiteCalDAVOperationRepo(db)
+	user, err := userRepo.Create(ctx, "testuser")
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	if err := calendarRepo.Create(ctx, &domain.Calendar{UserID: user.ID, Name: "default", DisplayName: "Calendar"}); err != nil {
+		t.Fatalf("create calendar: %v", err)
+	}
+
+	handler := NewHandlerWithReposAndOperationRecorder(db, userRepo, calendarRepo, eventRepo, operationRepo)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	icsData := `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VEVENT
+UID:private-event-1
+DTSTAMP:20260116T080000Z
+SUMMARY:Sensitive Doctor Appointment
+DTSTART:20260116T090000Z
+DTEND:20260116T100000Z
+END:VEVENT
+END:VCALENDAR`
+
+	req, err := http.NewRequest("PUT", srv.URL+"/dav/calendars/testuser/default/private-event-1.ics", strings.NewReader(icsData))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.SetBasicAuth("testuser", "testpass")
+	req.Header.Set("Content-Type", "text/calendar")
+	req.Header.Set("User-Agent", "Fantastical/4.0")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("PUT status = %d, want 201/204", resp.StatusCode)
+	}
+
+	operations, err := operationRepo.ListRecent(ctx, 10)
+	if err != nil {
+		t.Fatalf("list operations: %v", err)
+	}
+	if len(operations) == 0 {
+		t.Fatal("expected at least one operation record")
+	}
+	op := operations[0]
+	if op.Method != "PUT" {
+		t.Fatalf("method = %q, want PUT", op.Method)
+	}
+	if op.ClientFingerprint != domain.CalDAVClientFantastical {
+		t.Fatalf("client = %q, want fantastical", op.ClientFingerprint)
+	}
+	if op.OperationKind != domain.CalDAVOperationWrite {
+		t.Fatalf("kind = %q, want write", op.OperationKind)
+	}
+	if op.PathPattern != "/dav/calendars/{principal}/{calendar}/{object}.ics" {
+		t.Fatalf("path pattern = %q", op.PathPattern)
+	}
+
+	serialized := strings.Join([]string{op.PathPattern, op.RedactedError, op.ClientFingerprint, op.Method}, " ")
+	for _, forbidden := range []string{"BEGIN:VCALENDAR", "Sensitive Doctor Appointment", "private-event-1", "testuser", "default"} {
+		if strings.Contains(serialized, forbidden) {
+			t.Fatalf("operation metadata leaked private content %q in %q", forbidden, serialized)
+		}
+	}
+}

--- a/server/internal/caldav/operation_metadata_test.go
+++ b/server/internal/caldav/operation_metadata_test.go
@@ -72,7 +72,9 @@ func TestOperationClassification(t *testing.T) {
 		t.Fatalf("GET outcome = %q, want success", readOp.Outcome)
 	}
 
-	writeOp := BuildCalDAVOperation("PUT", "/dav/calendars/user/default/event.ics", http.StatusCreated, 10*time.Millisecond, http.Header{}, http.Header{"ETag": []string{"abc"}}, "Custom/1", 200, 0)
+	responseHeader := http.Header{}
+	responseHeader.Set("ETag", "abc")
+	writeOp := BuildCalDAVOperation("PUT", "/dav/calendars/user/default/event.ics", http.StatusCreated, 10*time.Millisecond, http.Header{}, responseHeader, "Custom/1", 200, 0)
 	if writeOp.OperationKind != domain.CalDAVOperationWrite {
 		t.Fatalf("PUT kind = %q, want write", writeOp.OperationKind)
 	}

--- a/server/internal/caldav/operation_metadata_test.go
+++ b/server/internal/caldav/operation_metadata_test.go
@@ -52,7 +52,8 @@ func TestRedactCalDAVPath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := RedactCalDAVPath(tt.path); got != tt.want {
+			got := RedactCalDAVPath(tt.path)
+			if got != tt.want {
 				t.Fatalf("RedactCalDAVPath() = %q, want %q", got, tt.want)
 			}
 			if strings.Contains(got, "alice") || strings.Contains(got, "doctor") || strings.Contains(got, "private-work") {

--- a/server/internal/caldav/operation_middleware.go
+++ b/server/internal/caldav/operation_middleware.go
@@ -1,0 +1,62 @@
+package caldav
+
+import (
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/airplne/calendar-app/server/internal/domain"
+)
+
+// OperationMetadataMiddleware records redacted CalDAV request metadata. It must
+// not inspect or persist request/response bodies.
+func OperationMetadataMiddleware(recorder domain.CalDAVOperationRepo) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if recorder == nil {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			started := time.Now()
+			wrapped := &operationResponseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+			next.ServeHTTP(wrapped, r)
+
+			operation := BuildCalDAVOperation(
+				r.Method,
+				r.URL.Path,
+				wrapped.statusCode,
+				time.Since(started),
+				r.Header,
+				wrapped.Header(),
+				r.UserAgent(),
+				r.ContentLength,
+				wrapped.bytesWritten,
+			)
+			if err := recorder.Record(&operation); err != nil {
+				// Recording must never break CalDAV request handling.
+				slog.Warn("failed to record CalDAV operation metadata", "error", err)
+			}
+		})
+	}
+}
+
+type operationResponseWriter struct {
+	http.ResponseWriter
+	statusCode   int
+	bytesWritten int64
+}
+
+func (w *operationResponseWriter) WriteHeader(code int) {
+	w.statusCode = code
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *operationResponseWriter) Write(data []byte) (int, error) {
+	if w.statusCode == 0 {
+		w.statusCode = http.StatusOK
+	}
+	n, err := w.ResponseWriter.Write(data)
+	w.bytesWritten += int64(n)
+	return n, err
+}

--- a/server/internal/data/sqlite_caldav_operation_repo.go
+++ b/server/internal/data/sqlite_caldav_operation_repo.go
@@ -53,9 +53,9 @@ func (r *SQLiteCalDAVOperationRepo) Record(operation *domain.CalDAVOperation) er
 	query := `
 		INSERT INTO caldav_operations (
 			operation_id, occurred_at, method, path_pattern, status_code, duration_ms,
-			client_user_agent, client_fingerprint, etag_outcome, operation_kind, outcome,
+			client_fingerprint, etag_outcome, operation_kind, outcome,
 			error_code, redacted_error, request_size_bytes, response_size_bytes
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`
 	_, err := r.db.ExecContext(context.Background(), query,
 		operation.ID,
@@ -64,7 +64,6 @@ func (r *SQLiteCalDAVOperationRepo) Record(operation *domain.CalDAVOperation) er
 		operation.PathPattern,
 		operation.StatusCode,
 		operation.DurationMillis,
-		operation.ClientUserAgent,
 		operation.ClientFingerprint,
 		string(operation.ETagOutcome),
 		string(operation.OperationKind),
@@ -106,7 +105,7 @@ func (r *SQLiteCalDAVOperationRepo) ListRecent(ctx context.Context, limit int) (
 	}
 	rows, err := r.db.QueryContext(ctx, `
 		SELECT operation_id, occurred_at, method, path_pattern, status_code, duration_ms,
-		       client_user_agent, client_fingerprint, etag_outcome, operation_kind, outcome,
+		       client_fingerprint, etag_outcome, operation_kind, outcome,
 		       error_code, redacted_error, request_size_bytes, response_size_bytes
 		FROM caldav_operations
 		ORDER BY occurred_at DESC, id DESC
@@ -128,7 +127,6 @@ func (r *SQLiteCalDAVOperationRepo) ListRecent(ctx context.Context, limit int) (
 			&op.PathPattern,
 			&op.StatusCode,
 			&op.DurationMillis,
-			&op.ClientUserAgent,
 			&op.ClientFingerprint,
 			&etagOutcome,
 			&kind,

--- a/server/internal/data/sqlite_caldav_operation_repo.go
+++ b/server/internal/data/sqlite_caldav_operation_repo.go
@@ -1,0 +1,153 @@
+package data
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/airplne/calendar-app/server/internal/domain"
+)
+
+const (
+	DefaultCalDAVOperationRetentionCount = 1000
+	DefaultCalDAVOperationRetentionAge   = 14 * 24 * time.Hour
+)
+
+// SQLiteCalDAVOperationRepo persists redacted CalDAV operation metadata.
+type SQLiteCalDAVOperationRepo struct {
+	db             *sql.DB
+	retentionCount int
+	retentionAge   time.Duration
+}
+
+func NewSQLiteCalDAVOperationRepo(db *sql.DB) *SQLiteCalDAVOperationRepo {
+	return &SQLiteCalDAVOperationRepo{
+		db:             db,
+		retentionCount: DefaultCalDAVOperationRetentionCount,
+		retentionAge:   DefaultCalDAVOperationRetentionAge,
+	}
+}
+
+func NewSQLiteCalDAVOperationRepoWithRetention(db *sql.DB, count int, age time.Duration) *SQLiteCalDAVOperationRepo {
+	if count <= 0 {
+		count = DefaultCalDAVOperationRetentionCount
+	}
+	if age <= 0 {
+		age = DefaultCalDAVOperationRetentionAge
+	}
+	return &SQLiteCalDAVOperationRepo{db: db, retentionCount: count, retentionAge: age}
+}
+
+func (r *SQLiteCalDAVOperationRepo) Record(operation *domain.CalDAVOperation) error {
+	if operation == nil {
+		return fmt.Errorf("caldav operation is nil")
+	}
+	if operation.ID == "" {
+		operation.ID = fmt.Sprintf("caldav-%d", time.Now().UnixNano())
+	}
+	if operation.OccurredAt.IsZero() {
+		operation.OccurredAt = time.Now().UTC()
+	}
+
+	query := `
+		INSERT INTO caldav_operations (
+			operation_id, occurred_at, method, path_pattern, status_code, duration_ms,
+			client_user_agent, client_fingerprint, etag_outcome, operation_kind, outcome,
+			error_code, redacted_error, request_size_bytes, response_size_bytes
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`
+	_, err := r.db.ExecContext(context.Background(), query,
+		operation.ID,
+		operation.OccurredAt,
+		operation.Method,
+		operation.PathPattern,
+		operation.StatusCode,
+		operation.DurationMillis,
+		operation.ClientUserAgent,
+		operation.ClientFingerprint,
+		string(operation.ETagOutcome),
+		string(operation.OperationKind),
+		string(operation.Outcome),
+		string(operation.ErrorCode),
+		operation.RedactedError,
+		operation.RequestSizeBytes,
+		operation.ResponseSizeBytes,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to record CalDAV operation: %w", err)
+	}
+	return r.Prune()
+}
+
+func (r *SQLiteCalDAVOperationRepo) Prune() error {
+	cutoff := time.Now().UTC().Add(-r.retentionAge)
+	if _, err := r.db.ExecContext(context.Background(), `DELETE FROM caldav_operations WHERE occurred_at < ?`, cutoff); err != nil {
+		return fmt.Errorf("failed to prune old CalDAV operations: %w", err)
+	}
+
+	query := `
+		DELETE FROM caldav_operations
+		WHERE id NOT IN (
+			SELECT id FROM caldav_operations
+			ORDER BY occurred_at DESC, id DESC
+			LIMIT ?
+		)
+	`
+	if _, err := r.db.ExecContext(context.Background(), query, r.retentionCount); err != nil {
+		return fmt.Errorf("failed to prune CalDAV operations by count: %w", err)
+	}
+	return nil
+}
+
+func (r *SQLiteCalDAVOperationRepo) ListRecent(ctx context.Context, limit int) ([]*domain.CalDAVOperation, error) {
+	if limit <= 0 || limit > r.retentionCount {
+		limit = r.retentionCount
+	}
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT operation_id, occurred_at, method, path_pattern, status_code, duration_ms,
+		       client_user_agent, client_fingerprint, etag_outcome, operation_kind, outcome,
+		       error_code, redacted_error, request_size_bytes, response_size_bytes
+		FROM caldav_operations
+		ORDER BY occurred_at DESC, id DESC
+		LIMIT ?
+	`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list CalDAV operations: %w", err)
+	}
+	defer rows.Close()
+
+	var operations []*domain.CalDAVOperation
+	for rows.Next() {
+		op := &domain.CalDAVOperation{}
+		var etagOutcome, kind, outcome, errorCode string
+		if err := rows.Scan(
+			&op.ID,
+			&op.OccurredAt,
+			&op.Method,
+			&op.PathPattern,
+			&op.StatusCode,
+			&op.DurationMillis,
+			&op.ClientUserAgent,
+			&op.ClientFingerprint,
+			&etagOutcome,
+			&kind,
+			&outcome,
+			&errorCode,
+			&op.RedactedError,
+			&op.RequestSizeBytes,
+			&op.ResponseSizeBytes,
+		); err != nil {
+			return nil, fmt.Errorf("failed to scan CalDAV operation: %w", err)
+		}
+		op.ETagOutcome = domain.CalDAVETagOutcome(etagOutcome)
+		op.OperationKind = domain.CalDAVOperationKind(kind)
+		op.Outcome = domain.CalDAVOperationOutcome(outcome)
+		op.ErrorCode = domain.CalDAVErrorCode(errorCode)
+		operations = append(operations, op)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate CalDAV operations: %w", err)
+	}
+	return operations, nil
+}

--- a/server/internal/data/sqlite_caldav_operation_repo_test.go
+++ b/server/internal/data/sqlite_caldav_operation_repo_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -21,7 +22,6 @@ func TestSQLiteCalDAVOperationRepo_RecordAndListRecent(t *testing.T) {
 		PathPattern:       "/dav/calendars/{principal}/{calendar}/{object}.ics",
 		StatusCode:        412,
 		DurationMillis:    25,
-		ClientUserAgent:   "Fantastical/4.0",
 		ClientFingerprint: domain.CalDAVClientFantastical,
 		ETagOutcome:       domain.CalDAVETagMismatched,
 		OperationKind:     domain.CalDAVOperationWrite,
@@ -43,8 +43,59 @@ func TestSQLiteCalDAVOperationRepo_RecordAndListRecent(t *testing.T) {
 		t.Fatalf("len(operations) = %d, want 1", len(operations))
 	}
 	got := operations[0]
-	if got.ID != op.ID || got.Method != op.Method || got.PathPattern != op.PathPattern || got.ErrorCode != op.ErrorCode {
+	if got.ID != op.ID || got.Method != op.Method || got.PathPattern != op.PathPattern || got.ErrorCode != op.ErrorCode || got.ClientFingerprint != op.ClientFingerprint {
 		t.Fatalf("operation mismatch: got %+v want %+v", got, op)
+	}
+}
+
+func TestSQLiteCalDAVOperationRepo_DoesNotPersistRawUserAgent(t *testing.T) {
+	db := openOperationTestDB(t)
+	repo := NewSQLiteCalDAVOperationRepoWithRetention(db, 10, 14*24*time.Hour)
+	privateUA := "PrivateDeviceName/SecretBuildToken CalendarClient"
+
+	op := operationFixture("op-private-ua", time.Now().UTC())
+	op.ClientFingerprint = domain.CalDAVClientUnknown
+	if err := repo.Record(op); err != nil {
+		t.Fatalf("Record() error = %v", err)
+	}
+
+	operations, err := repo.ListRecent(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("ListRecent() error = %v", err)
+	}
+	if len(operations) != 1 {
+		t.Fatalf("len(operations) = %d, want 1", len(operations))
+	}
+	if operations[0].ClientFingerprint != domain.CalDAVClientUnknown {
+		t.Fatalf("ClientFingerprint = %q, want %q", operations[0].ClientFingerprint, domain.CalDAVClientUnknown)
+	}
+
+	var tableSQL string
+	if err := db.QueryRowContext(context.Background(), `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'caldav_operations'`).Scan(&tableSQL); err != nil {
+		t.Fatalf("failed to read table schema: %v", err)
+	}
+	if strings.Contains(tableSQL, "client_user_agent") {
+		t.Fatalf("caldav_operations schema should not include raw user-agent column: %s", tableSQL)
+	}
+
+	rows, err := db.QueryContext(context.Background(), `SELECT operation_id, method, path_pattern, client_fingerprint, etag_outcome, operation_kind, outcome, error_code, redacted_error FROM caldav_operations`)
+	if err != nil {
+		t.Fatalf("failed to query persisted metadata: %v", err)
+	}
+	defer rows.Close()
+	var persisted strings.Builder
+	for rows.Next() {
+		var cols [9]string
+		if err := rows.Scan(&cols[0], &cols[1], &cols[2], &cols[3], &cols[4], &cols[5], &cols[6], &cols[7], &cols[8]); err != nil {
+			t.Fatalf("failed to scan persisted metadata: %v", err)
+		}
+		persisted.WriteString(strings.Join(cols[:], " "))
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("failed to iterate persisted metadata: %v", err)
+	}
+	if strings.Contains(persisted.String(), privateUA) || strings.Contains(persisted.String(), "SecretBuildToken") || strings.Contains(persisted.String(), "PrivateDeviceName") {
+		t.Fatalf("persisted metadata leaked raw user-agent: %q", persisted.String())
 	}
 }
 

--- a/server/internal/data/sqlite_caldav_operation_repo_test.go
+++ b/server/internal/data/sqlite_caldav_operation_repo_test.go
@@ -1,0 +1,126 @@
+package data
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/airplne/calendar-app/server/internal/domain"
+)
+
+func TestSQLiteCalDAVOperationRepo_RecordAndListRecent(t *testing.T) {
+	db := openOperationTestDB(t)
+	repo := NewSQLiteCalDAVOperationRepoWithRetention(db, 10, 14*24*time.Hour)
+
+	op := &domain.CalDAVOperation{
+		ID:                "op-1",
+		OccurredAt:        time.Date(2026, 4, 26, 12, 0, 0, 0, time.UTC),
+		Method:            "PUT",
+		PathPattern:       "/dav/calendars/{principal}/{calendar}/{object}.ics",
+		StatusCode:        412,
+		DurationMillis:    25,
+		ClientUserAgent:   "Fantastical/4.0",
+		ClientFingerprint: domain.CalDAVClientFantastical,
+		ETagOutcome:       domain.CalDAVETagMismatched,
+		OperationKind:     domain.CalDAVOperationWrite,
+		Outcome:           domain.CalDAVOperationRecoverableFailure,
+		ErrorCode:         domain.CalDAVErrorETagConflict,
+		RedactedError:     "ETag precondition failed.",
+		RequestSizeBytes:  123,
+		ResponseSizeBytes: 45,
+	}
+	if err := repo.Record(op); err != nil {
+		t.Fatalf("Record() error = %v", err)
+	}
+
+	operations, err := repo.ListRecent(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("ListRecent() error = %v", err)
+	}
+	if len(operations) != 1 {
+		t.Fatalf("len(operations) = %d, want 1", len(operations))
+	}
+	got := operations[0]
+	if got.ID != op.ID || got.Method != op.Method || got.PathPattern != op.PathPattern || got.ErrorCode != op.ErrorCode {
+		t.Fatalf("operation mismatch: got %+v want %+v", got, op)
+	}
+}
+
+func TestSQLiteCalDAVOperationRepo_PrunesByCount(t *testing.T) {
+	db := openOperationTestDB(t)
+	repo := NewSQLiteCalDAVOperationRepoWithRetention(db, 2, 14*24*time.Hour)
+	base := time.Date(2026, 4, 26, 12, 0, 0, 0, time.UTC)
+
+	for i := 0; i < 3; i++ {
+		op := operationFixture("op-count-"+string(rune('a'+i)), base.Add(time.Duration(i)*time.Minute))
+		if err := repo.Record(op); err != nil {
+			t.Fatalf("Record(%d) error = %v", i, err)
+		}
+	}
+
+	operations, err := repo.ListRecent(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("ListRecent() error = %v", err)
+	}
+	if len(operations) != 2 {
+		t.Fatalf("len(operations) = %d, want 2", len(operations))
+	}
+	if operations[0].ID != "op-count-c" || operations[1].ID != "op-count-b" {
+		t.Fatalf("unexpected retained operations: got %s, %s", operations[0].ID, operations[1].ID)
+	}
+}
+
+func TestSQLiteCalDAVOperationRepo_PrunesByAge(t *testing.T) {
+	db := openOperationTestDB(t)
+	repo := NewSQLiteCalDAVOperationRepoWithRetention(db, 10, time.Hour)
+
+	oldOp := operationFixture("op-old", time.Now().UTC().Add(-2*time.Hour))
+	newOp := operationFixture("op-new", time.Now().UTC())
+	if err := repo.Record(oldOp); err != nil {
+		t.Fatalf("Record(old) error = %v", err)
+	}
+	if err := repo.Record(newOp); err != nil {
+		t.Fatalf("Record(new) error = %v", err)
+	}
+
+	operations, err := repo.ListRecent(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("ListRecent() error = %v", err)
+	}
+	if len(operations) != 1 {
+		t.Fatalf("len(operations) = %d, want 1", len(operations))
+	}
+	if operations[0].ID != "op-new" {
+		t.Fatalf("retained operation = %q, want op-new", operations[0].ID)
+	}
+}
+
+func operationFixture(id string, occurredAt time.Time) *domain.CalDAVOperation {
+	return &domain.CalDAVOperation{
+		ID:                id,
+		OccurredAt:        occurredAt,
+		Method:            "GET",
+		PathPattern:       "/dav/calendars/{principal}/{calendar}/{object}.ics",
+		StatusCode:        200,
+		DurationMillis:    5,
+		ClientFingerprint: domain.CalDAVClientUnknown,
+		ETagOutcome:       domain.CalDAVETagNotApplicable,
+		OperationKind:     domain.CalDAVOperationRead,
+		Outcome:           domain.CalDAVOperationSuccess,
+	}
+}
+
+func openOperationTestDB(t *testing.T) *DBWrapper {
+	t.Helper()
+	db, err := OpenDB(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenDB() error = %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	migrationsDir := filepath.Join("..", "..", "migrations")
+	if err := RunMigrations(db, migrationsDir); err != nil {
+		t.Fatalf("RunMigrations() error = %v", err)
+	}
+	return db
+}

--- a/server/internal/data/sqlite_caldav_operation_repo_test.go
+++ b/server/internal/data/sqlite_caldav_operation_repo_test.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"context"
+	"database/sql"
 	"path/filepath"
 	"testing"
 	"time"
@@ -111,7 +112,7 @@ func operationFixture(id string, occurredAt time.Time) *domain.CalDAVOperation {
 	}
 }
 
-func openOperationTestDB(t *testing.T) *DBWrapper {
+func openOperationTestDB(t *testing.T) *sql.DB {
 	t.Helper()
 	db, err := OpenDB(t.TempDir())
 	if err != nil {

--- a/server/internal/domain/caldav_operation.go
+++ b/server/internal/domain/caldav_operation.go
@@ -92,6 +92,34 @@ func (op CalDAVOperation) IsETagConflict() bool {
 	return op.ErrorCode == CalDAVErrorETagConflict || op.ETagOutcome == CalDAVETagMismatched
 }
 
+// SummarizeCalDAVOperations adapts redacted operation records into the issue #11
+// Sync Health evaluator input shape. This keeps future APIs/debug bundles from
+// needing raw event data to compute health.
+func SummarizeCalDAVOperations(operations []*CalDAVOperation) RecentOperationSummary {
+	summary := RecentOperationSummary{HasRecentOperationData: len(operations) > 0}
+	for _, op := range operations {
+		if op == nil {
+			continue
+		}
+		if op.IsWriteFailure() {
+			summary.WriteFailures++
+		}
+		if op.IsETagConflict() {
+			summary.ETagConflicts++
+		}
+		if op.IsRecoverableFailure() {
+			summary.RecoverableClientSyncFailures++
+		}
+		if op.IsIntegrityFailure() {
+			summary.CorruptICSIncidents++
+		}
+		if op.ErrorCode == CalDAVErrorDuplicateUID {
+			summary.UnresolvedDuplicateUIDs++
+		}
+	}
+	return summary
+}
+
 // CalDAVOperationRepo persists redacted operation metadata. Implementations must
 // enforce bounded retention and must not persist raw calendar data.
 type CalDAVOperationRepo interface {

--- a/server/internal/domain/caldav_operation.go
+++ b/server/internal/domain/caldav_operation.go
@@ -57,7 +57,7 @@ const (
 
 // CalDAVOperation is redacted request metadata used by Sync Health and diagnostics.
 // It intentionally stores no raw ICS, event body, title, description, attendee,
-// task, LLM, or Todoist content.
+// task, LLM, Todoist content, or raw user-agent by default.
 type CalDAVOperation struct {
 	ID                string
 	OccurredAt        time.Time
@@ -65,7 +65,6 @@ type CalDAVOperation struct {
 	PathPattern       string
 	StatusCode        int
 	DurationMillis    int64
-	ClientUserAgent   string
 	ClientFingerprint string
 	ETagOutcome       CalDAVETagOutcome
 	OperationKind     CalDAVOperationKind
@@ -89,7 +88,7 @@ func (op CalDAVOperation) IsIntegrityFailure() bool {
 }
 
 func (op CalDAVOperation) IsETagConflict() bool {
-	return op.ErrorCode == CalDAVErrorETagConflict || op.ETagOutcome == CalDAVETagMismatched
+	return op.ErrorCode == CalDAVErrorETagConflict || op.ETagOutcome == CalDAVETagMismatched || op.StatusCode == 412
 }
 
 // SummarizeCalDAVOperations adapts redacted operation records into the issue #11
@@ -101,20 +100,29 @@ func SummarizeCalDAVOperations(operations []*CalDAVOperation) RecentOperationSum
 		if op == nil {
 			continue
 		}
+
 		if op.IsWriteFailure() {
 			summary.WriteFailures++
-		}
-		if op.IsETagConflict() {
-			summary.ETagConflicts++
 		}
 		if op.IsRecoverableFailure() {
 			summary.RecoverableClientSyncFailures++
 		}
-		if op.IsIntegrityFailure() {
-			summary.CorruptICSIncidents++
+		if op.IsETagConflict() {
+			summary.ETagConflicts++
 		}
-		if op.ErrorCode == CalDAVErrorDuplicateUID {
+		if op.OperationKind == CalDAVOperationWrite && op.StatusCode >= 500 {
+			summary.CalendarWritePathFailing = true
+		}
+
+		switch op.ErrorCode {
+		case CalDAVErrorCorruptICS, CalDAVErrorParse:
+			summary.CorruptICSIncidents++
+		case CalDAVErrorDuplicateUID:
 			summary.UnresolvedDuplicateUIDs++
+		case CalDAVErrorWriteFailed:
+			if op.OperationKind == CalDAVOperationWrite {
+				summary.CalendarWritePathFailing = true
+			}
 		}
 	}
 	return summary

--- a/server/internal/domain/caldav_operation.go
+++ b/server/internal/domain/caldav_operation.go
@@ -1,0 +1,100 @@
+package domain
+
+import "time"
+
+// CalDAVOperationKind describes whether a CalDAV request primarily reads or writes data.
+type CalDAVOperationKind string
+
+const (
+	CalDAVOperationRead  CalDAVOperationKind = "read"
+	CalDAVOperationWrite CalDAVOperationKind = "write"
+)
+
+// CalDAVOperationOutcome classifies the result of a CalDAV operation for Sync Health.
+type CalDAVOperationOutcome string
+
+const (
+	CalDAVOperationSuccess            CalDAVOperationOutcome = "success"
+	CalDAVOperationRecoverableFailure CalDAVOperationOutcome = "recoverable_failure"
+	CalDAVOperationIntegrityFailure   CalDAVOperationOutcome = "integrity_failure"
+)
+
+// CalDAVETagOutcome captures safe ETag/precondition metadata.
+type CalDAVETagOutcome string
+
+const (
+	CalDAVETagNotApplicable CalDAVETagOutcome = "not_applicable"
+	CalDAVETagMatched       CalDAVETagOutcome = "matched"
+	CalDAVETagMismatched    CalDAVETagOutcome = "mismatched"
+	CalDAVETagMissing       CalDAVETagOutcome = "missing"
+	CalDAVETagGenerated     CalDAVETagOutcome = "generated"
+)
+
+// CalDAVErrorCode is a redacted diagnostic category. It must not include raw parser
+// output, raw ICS, event descriptions, attendee emails, or task content.
+type CalDAVErrorCode string
+
+const (
+	CalDAVErrorNone              CalDAVErrorCode = ""
+	CalDAVErrorParse             CalDAVErrorCode = "parse_error"
+	CalDAVErrorETagConflict      CalDAVErrorCode = "etag_conflict"
+	CalDAVErrorDuplicateUID      CalDAVErrorCode = "duplicate_uid"
+	CalDAVErrorCorruptICS        CalDAVErrorCode = "corrupt_ics"
+	CalDAVErrorWriteFailed       CalDAVErrorCode = "write_failed"
+	CalDAVErrorAuthFailed        CalDAVErrorCode = "auth_failed"
+	CalDAVErrorUnsupportedMethod CalDAVErrorCode = "unsupported_method"
+	CalDAVErrorUnknown           CalDAVErrorCode = "unknown_error"
+)
+
+// CalDAV client fingerprints are normalized, debug-bundle-safe identifiers.
+const (
+	CalDAVClientAppleCalendar = "apple-calendar"
+	CalDAVClientFantastical   = "fantastical"
+	CalDAVClientDAVx5         = "davx5"
+	CalDAVClientThunderbird   = "thunderbird"
+	CalDAVClientUnknown       = "unknown-caldav-client"
+)
+
+// CalDAVOperation is redacted request metadata used by Sync Health and diagnostics.
+// It intentionally stores no raw ICS, event body, title, description, attendee,
+// task, LLM, or Todoist content.
+type CalDAVOperation struct {
+	ID                string
+	OccurredAt        time.Time
+	Method            string
+	PathPattern       string
+	StatusCode        int
+	DurationMillis    int64
+	ClientUserAgent   string
+	ClientFingerprint string
+	ETagOutcome       CalDAVETagOutcome
+	OperationKind     CalDAVOperationKind
+	Outcome           CalDAVOperationOutcome
+	ErrorCode         CalDAVErrorCode
+	RedactedError     string
+	RequestSizeBytes  int64
+	ResponseSizeBytes int64
+}
+
+func (op CalDAVOperation) IsWriteFailure() bool {
+	return op.OperationKind == CalDAVOperationWrite && op.Outcome != CalDAVOperationSuccess
+}
+
+func (op CalDAVOperation) IsRecoverableFailure() bool {
+	return op.Outcome == CalDAVOperationRecoverableFailure
+}
+
+func (op CalDAVOperation) IsIntegrityFailure() bool {
+	return op.Outcome == CalDAVOperationIntegrityFailure
+}
+
+func (op CalDAVOperation) IsETagConflict() bool {
+	return op.ErrorCode == CalDAVErrorETagConflict || op.ETagOutcome == CalDAVETagMismatched
+}
+
+// CalDAVOperationRepo persists redacted operation metadata. Implementations must
+// enforce bounded retention and must not persist raw calendar data.
+type CalDAVOperationRepo interface {
+	Record(operation *CalDAVOperation) error
+	Prune() error
+}

--- a/server/internal/domain/caldav_operation_test.go
+++ b/server/internal/domain/caldav_operation_test.go
@@ -1,0 +1,97 @@
+package domain
+
+import "testing"
+
+func TestSummarizeCalDAVOperations_CorruptICS(t *testing.T) {
+	summary := SummarizeCalDAVOperations([]*CalDAVOperation{{
+		OperationKind: CalDAVOperationRead,
+		Outcome:       CalDAVOperationIntegrityFailure,
+		ErrorCode:     CalDAVErrorCorruptICS,
+	}})
+
+	if summary.CorruptICSIncidents != 1 {
+		t.Fatalf("CorruptICSIncidents = %d, want 1", summary.CorruptICSIncidents)
+	}
+	if summary.UnresolvedDuplicateUIDs != 0 {
+		t.Fatalf("UnresolvedDuplicateUIDs = %d, want 0", summary.UnresolvedDuplicateUIDs)
+	}
+}
+
+func TestSummarizeCalDAVOperations_ParseErrorCountsAsCorruptICS(t *testing.T) {
+	summary := SummarizeCalDAVOperations([]*CalDAVOperation{{
+		OperationKind: CalDAVOperationRead,
+		Outcome:       CalDAVOperationIntegrityFailure,
+		ErrorCode:     CalDAVErrorParse,
+	}})
+
+	if summary.CorruptICSIncidents != 1 {
+		t.Fatalf("CorruptICSIncidents = %d, want 1", summary.CorruptICSIncidents)
+	}
+}
+
+func TestSummarizeCalDAVOperations_DuplicateUIDDoesNotCountAsCorruptICS(t *testing.T) {
+	summary := SummarizeCalDAVOperations([]*CalDAVOperation{{
+		OperationKind: CalDAVOperationWrite,
+		Outcome:       CalDAVOperationIntegrityFailure,
+		ErrorCode:     CalDAVErrorDuplicateUID,
+	}})
+
+	if summary.UnresolvedDuplicateUIDs != 1 {
+		t.Fatalf("UnresolvedDuplicateUIDs = %d, want 1", summary.UnresolvedDuplicateUIDs)
+	}
+	if summary.CorruptICSIncidents != 0 {
+		t.Fatalf("CorruptICSIncidents = %d, want 0", summary.CorruptICSIncidents)
+	}
+}
+
+func TestSummarizeCalDAVOperations_ETagConflictCountsOnce(t *testing.T) {
+	summary := SummarizeCalDAVOperations([]*CalDAVOperation{{
+		StatusCode:    412,
+		OperationKind: CalDAVOperationWrite,
+		Outcome:       CalDAVOperationRecoverableFailure,
+		ErrorCode:     CalDAVErrorETagConflict,
+		ETagOutcome:   CalDAVETagMismatched,
+	}})
+
+	if summary.ETagConflicts != 1 {
+		t.Fatalf("ETagConflicts = %d, want 1", summary.ETagConflicts)
+	}
+	if summary.CorruptICSIncidents != 0 {
+		t.Fatalf("CorruptICSIncidents = %d, want 0", summary.CorruptICSIncidents)
+	}
+}
+
+func TestSummarizeCalDAVOperations_GenericWriteFailureDoesNotCountAsCorruptICS(t *testing.T) {
+	summary := SummarizeCalDAVOperations([]*CalDAVOperation{{
+		StatusCode:    500,
+		OperationKind: CalDAVOperationWrite,
+		Outcome:       CalDAVOperationIntegrityFailure,
+		ErrorCode:     CalDAVErrorWriteFailed,
+	}})
+
+	if summary.WriteFailures != 1 {
+		t.Fatalf("WriteFailures = %d, want 1", summary.WriteFailures)
+	}
+	if !summary.CalendarWritePathFailing {
+		t.Fatal("CalendarWritePathFailing = false, want true")
+	}
+	if summary.CorruptICSIncidents != 0 {
+		t.Fatalf("CorruptICSIncidents = %d, want 0", summary.CorruptICSIncidents)
+	}
+}
+
+func TestSummarizeCalDAVOperations_Generic5xxIntegrityFailureDoesNotCountAsCorruptICS(t *testing.T) {
+	summary := SummarizeCalDAVOperations([]*CalDAVOperation{{
+		StatusCode:    500,
+		OperationKind: CalDAVOperationRead,
+		Outcome:       CalDAVOperationIntegrityFailure,
+		ErrorCode:     CalDAVErrorUnknown,
+	}})
+
+	if summary.CorruptICSIncidents != 0 {
+		t.Fatalf("CorruptICSIncidents = %d, want 0", summary.CorruptICSIncidents)
+	}
+	if summary.UnresolvedDuplicateUIDs != 0 {
+		t.Fatalf("UnresolvedDuplicateUIDs = %d, want 0", summary.UnresolvedDuplicateUIDs)
+	}
+}

--- a/server/migrations/00002_caldav_operations.sql
+++ b/server/migrations/00002_caldav_operations.sql
@@ -1,6 +1,6 @@
 -- +goose Up
 -- Redacted CalDAV operation metadata for Sync Health diagnostics.
--- Stores request metadata only; never stores raw ICS or event descriptions.
+-- Stores request metadata only; never stores raw ICS, event descriptions, or raw user-agent strings.
 
 CREATE TABLE IF NOT EXISTS caldav_operations (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -10,7 +10,6 @@ CREATE TABLE IF NOT EXISTS caldav_operations (
     path_pattern TEXT NOT NULL,
     status_code INTEGER NOT NULL,
     duration_ms INTEGER NOT NULL,
-    client_user_agent TEXT,
     client_fingerprint TEXT NOT NULL,
     etag_outcome TEXT NOT NULL,
     operation_kind TEXT NOT NULL,

--- a/server/migrations/00002_caldav_operations.sql
+++ b/server/migrations/00002_caldav_operations.sql
@@ -1,0 +1,39 @@
+-- +goose Up
+-- Redacted CalDAV operation metadata for Sync Health diagnostics.
+-- Stores request metadata only; never stores raw ICS or event descriptions.
+
+CREATE TABLE IF NOT EXISTS caldav_operations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    operation_id TEXT NOT NULL UNIQUE,
+    occurred_at DATETIME NOT NULL,
+    method TEXT NOT NULL,
+    path_pattern TEXT NOT NULL,
+    status_code INTEGER NOT NULL,
+    duration_ms INTEGER NOT NULL,
+    client_user_agent TEXT,
+    client_fingerprint TEXT NOT NULL,
+    etag_outcome TEXT NOT NULL,
+    operation_kind TEXT NOT NULL,
+    outcome TEXT NOT NULL,
+    error_code TEXT,
+    redacted_error TEXT,
+    request_size_bytes INTEGER DEFAULT 0,
+    response_size_bytes INTEGER DEFAULT 0,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_caldav_operations_occurred_at ON caldav_operations(occurred_at);
+CREATE INDEX IF NOT EXISTS idx_caldav_operations_method ON caldav_operations(method);
+CREATE INDEX IF NOT EXISTS idx_caldav_operations_client_fingerprint ON caldav_operations(client_fingerprint);
+CREATE INDEX IF NOT EXISTS idx_caldav_operations_status_code ON caldav_operations(status_code);
+CREATE INDEX IF NOT EXISTS idx_caldav_operations_outcome ON caldav_operations(outcome);
+CREATE INDEX IF NOT EXISTS idx_caldav_operations_error_code ON caldav_operations(error_code);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_caldav_operations_error_code;
+DROP INDEX IF EXISTS idx_caldav_operations_outcome;
+DROP INDEX IF EXISTS idx_caldav_operations_status_code;
+DROP INDEX IF EXISTS idx_caldav_operations_client_fingerprint;
+DROP INDEX IF EXISTS idx_caldav_operations_method;
+DROP INDEX IF EXISTS idx_caldav_operations_occurred_at;
+DROP TABLE IF EXISTS caldav_operations;


### PR DESCRIPTION
## Summary

Implements issue #12 by adding CalDAV operation metadata recording for Sync Health.

Closes #12.

## Scope

- Adds redacted CalDAV operation metadata domain model.
- Adds SQLite persistence with bounded retention.
- Adds middleware-based recording for CalDAV requests.
- Normalizes client fingerprints for Apple Calendar, Fantastical, DAVx5, Thunderbird, and unknown clients.
- Classifies operation kind/outcome, ETag outcomes, and redacted error categories.
- Redacts CalDAV paths so operation records do not expose principal, calendar, object UID, or event content.
- Adds tests for redaction, fingerprinting, classification, middleware recording, and retention pruning.

## Non-goals

- Does not implement Sync Health API.
- Does not implement debug bundle export.
- Does not implement onboarding green-sync gate.
- Does not add frontend work.
- Does not add LLM or Todoist behavior.

## Retention

Implemented in this PR with write-time pruning:

- latest 1,000 operations, or
- 14 days of operations,
- whichever limit is reached first.

## Tests

- [ ] `cd server && go test ./...`
