### PR TITLE
Build Sync Health API

### DIFF
--- a/server/cmd/calendarapp/main.go
+++ b/server/cmd/calendarapp/main.go
@@ -12,9 +12,11 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/airplne/calendar-app/server/internal/api"
 	"github.com/airplne/calendar-app/server/internal/caldav"
 	"github.com/airplne/calendar-app/server/internal/data"
 	"github.com/airplne/calendar-app/server/internal/domain"
+	"github.com/airplne/calendar-app/server/internal/services"
 	"github.com/airplne/calendar-app/server/internal/webui"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -85,6 +87,7 @@ func main() {
 	userRepo := data.NewSQLiteUserRepo(db)
 	calendarRepo := data.NewSQLiteCalendarRepo(db)
 	eventRepo := data.NewSQLiteEventRepo(db)
+	operationRepo := data.NewSQLiteCalDAVOperationRepo(db)
 
 	// Load auth config to get configured username
 	authConfig := caldav.LoadAuthConfig()
@@ -128,11 +131,15 @@ func main() {
 	// SSE endpoint stub
 	r.Get("/events", handleSSE)
 
+	// Sync Health API
+	syncHealthService := services.NewSyncHealthService(operationRepo, services.UnknownGreenSyncProvider())
+	r.Mount("/api/v1/sync-health", api.NewSyncHealthHandler(syncHealthService).Routes())
+
 	// Well-known CalDAV auto-discovery endpoint
 	r.Get("/.well-known/caldav", caldav.NewWellKnownRoutes(authConfig.Username).ServeHTTP)
 
 	// CalDAV mount point with repository access
-	r.Mount("/dav", caldav.NewHandlerWithRepos(db, userRepo, calendarRepo, eventRepo))
+	r.Mount("/dav", caldav.NewHandlerWithReposAndOperationRecorder(db, userRepo, calendarRepo, eventRepo, operationRepo))
 
 	// Web UI (embedded in production; placeholder when dist not built)
 	r.Mount("/", webui.Handler())

--- a/server/internal/api/sync_health.go
+++ b/server/internal/api/sync_health.go
@@ -1,0 +1,239 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/airplne/calendar-app/server/internal/domain"
+	"github.com/airplne/calendar-app/server/internal/services"
+)
+
+type SyncHealthHandler struct {
+	service *services.SyncHealthService
+}
+
+func NewSyncHealthHandler(service *services.SyncHealthService) *SyncHealthHandler {
+	return &SyncHealthHandler{service: service}
+}
+
+func (h *SyncHealthHandler) Routes() http.Handler {
+	r := chi.NewRouter()
+	r.Get("/", h.handleSummary)
+	r.Get("/operations", h.handleOperations)
+	r.Get("/clients", h.handleClients)
+	r.Post("/validation-event/start", h.handleValidationNotImplemented)
+	r.Post("/validation-event/verify", h.handleValidationNotImplemented)
+	return r
+}
+
+type syncHealthResponse struct {
+	Status               string                   `json:"status"`
+	EvaluatedAt          time.Time                `json:"evaluated_at"`
+	Reasons              []syncHealthReasonJSON   `json:"reasons"`
+	LastSuccessAt        *time.Time               `json:"last_success_at"`
+	LastFailureAt        *time.Time               `json:"last_failure_at"`
+	GreenSyncCompleted   bool                     `json:"green_sync_completed"`
+	GreenSyncCompletedAt *time.Time               `json:"green_sync_completed_at"`
+	GreenSyncState       string                   `json:"green_sync_state"`
+	OperationCounts      operationCountsJSON      `json:"operation_counts"`
+	LatencyMS            latencyJSON              `json:"latency_ms"`
+	Clients              []clientSummaryJSON      `json:"clients"`
+	RecentOperations     []recentOperationJSON    `json:"recent_operations,omitempty"`
+}
+
+type syncHealthReasonJSON struct {
+	Code     string `json:"code"`
+	Severity string `json:"severity"`
+	Message  string `json:"message"`
+}
+
+type operationCountsJSON struct {
+	Total                int `json:"total"`
+	Success              int `json:"success"`
+	Failure              int `json:"failure"`
+	ETagConflicts        int `json:"etag_conflicts"`
+	DuplicateUIDAttempts int `json:"duplicate_uid_attempts"`
+	ParseFailures        int `json:"parse_failures"`
+	CorruptICSIncidents  int `json:"corrupt_ics_incidents"`
+	WriteFailures        int `json:"write_failures"`
+}
+
+type latencyJSON struct {
+	Median int64 `json:"median"`
+	P95    int64 `json:"p95"`
+}
+
+type clientSummaryJSON struct {
+	Fingerprint       string    `json:"fingerprint"`
+	DisplayName       string    `json:"display_name"`
+	LastSeenAt        time.Time `json:"last_seen_at"`
+	OperationCount    int       `json:"operation_count"`
+	OperationCount24h int       `json:"operation_count_24h"`
+}
+
+type recentOperationJSON struct {
+	OccurredAt        time.Time `json:"occurred_at"`
+	Method            string    `json:"method"`
+	PathPattern       string    `json:"path_pattern"`
+	StatusCode        int       `json:"status_code"`
+	DurationMillis    int64     `json:"duration_ms"`
+	ClientFingerprint string    `json:"client_fingerprint"`
+	ETagOutcome       string    `json:"etag_outcome"`
+	OperationKind     string    `json:"operation_kind"`
+	Outcome           string    `json:"outcome"`
+	ErrorCode         string    `json:"error_code,omitempty"`
+	RedactedError     string    `json:"redacted_error,omitempty"`
+}
+
+func (h *SyncHealthHandler) handleSummary(w http.ResponseWriter, r *http.Request) {
+	summary, err := h.service.Summary(r.Context())
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "sync_health_unavailable", "Sync Health is unavailable.")
+		return
+	}
+	writeJSON(w, http.StatusOK, toSyncHealthResponse(summary, false))
+}
+
+func (h *SyncHealthHandler) handleOperations(w http.ResponseWriter, r *http.Request) {
+	limit := parseLimit(r, services.DefaultSyncHealthOperationLimit)
+	operations, err := h.service.RecentOperations(r.Context(), limit)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "sync_health_operations_unavailable", "Recent operations are unavailable.")
+		return
+	}
+	response := make([]recentOperationJSON, 0, len(operations))
+	for _, op := range operations {
+		response = append(response, toRecentOperationJSON(op))
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"operations": response})
+}
+
+func (h *SyncHealthHandler) handleClients(w http.ResponseWriter, r *http.Request) {
+	clients, err := h.service.Clients(r.Context())
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "sync_health_clients_unavailable", "Client summaries are unavailable.")
+		return
+	}
+	response := make([]clientSummaryJSON, 0, len(clients))
+	for _, client := range clients {
+		response = append(response, toClientSummaryJSON(client))
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"clients": response})
+}
+
+func (h *SyncHealthHandler) handleValidationNotImplemented(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusNotImplemented, map[string]any{
+		"status": "not_implemented",
+		"error_code": "green_sync_validation_not_implemented",
+		"message": "Green-sync validation flow is implemented in issue #15.",
+	})
+}
+
+func toSyncHealthResponse(summary *services.SyncHealthSummary, includeOperations bool) syncHealthResponse {
+	response := syncHealthResponse{
+		Status:               string(summary.Health.Status),
+		EvaluatedAt:          summary.Health.EvaluatedAt,
+		Reasons:              toReasonsJSON(summary.Health.Reasons),
+		LastSuccessAt:        summary.LastSuccessAt,
+		LastFailureAt:        summary.LastFailureAt,
+		GreenSyncCompleted:   summary.Health.GreenSyncCompleted,
+		GreenSyncCompletedAt: summary.Health.LastValidationAt,
+		GreenSyncState:       string(summary.Health.LastValidationState),
+		OperationCounts:      toOperationCountsJSON(summary.OperationCounts),
+		LatencyMS:            latencyJSON{Median: summary.Latency.MedianMillis, P95: summary.Latency.P95Millis},
+		Clients:              toClientsJSON(summary.Clients),
+	}
+	if includeOperations {
+		for _, op := range summary.Operations {
+			response.RecentOperations = append(response.RecentOperations, toRecentOperationJSON(op))
+		}
+	}
+	return response
+}
+
+func toReasonsJSON(reasons []domain.SyncHealthReason) []syncHealthReasonJSON {
+	out := make([]syncHealthReasonJSON, 0, len(reasons))
+	for _, reason := range reasons {
+		out = append(out, syncHealthReasonJSON{Code: reason.Code, Severity: string(reason.Severity), Message: reason.Message})
+	}
+	return out
+}
+
+func toOperationCountsJSON(counts services.SyncOperationCounts) operationCountsJSON {
+	return operationCountsJSON{
+		Total:                counts.Total,
+		Success:              counts.Success,
+		Failure:              counts.Failure,
+		ETagConflicts:        counts.ETagConflicts,
+		DuplicateUIDAttempts: counts.DuplicateUIDAttempts,
+		ParseFailures:        counts.ParseFailures,
+		CorruptICSIncidents:  counts.CorruptICSIncidents,
+		WriteFailures:        counts.WriteFailures,
+	}
+}
+
+func toClientsJSON(clients []services.SyncClientSummary) []clientSummaryJSON {
+	out := make([]clientSummaryJSON, 0, len(clients))
+	for _, client := range clients {
+		out = append(out, toClientSummaryJSON(client))
+	}
+	return out
+}
+
+func toClientSummaryJSON(client services.SyncClientSummary) clientSummaryJSON {
+	return clientSummaryJSON{
+		Fingerprint:       client.Fingerprint,
+		DisplayName:       client.DisplayName,
+		LastSeenAt:        client.LastSeenAt,
+		OperationCount:    client.OperationCount,
+		OperationCount24h: client.OperationCount24h,
+	}
+}
+
+func toRecentOperationJSON(op *domain.CalDAVOperation) recentOperationJSON {
+	if op == nil {
+		return recentOperationJSON{}
+	}
+	return recentOperationJSON{
+		OccurredAt:        op.OccurredAt,
+		Method:            op.Method,
+		PathPattern:       op.PathPattern,
+		StatusCode:        op.StatusCode,
+		DurationMillis:    op.DurationMillis,
+		ClientFingerprint: op.ClientFingerprint,
+		ETagOutcome:       string(op.ETagOutcome),
+		OperationKind:     string(op.OperationKind),
+		Outcome:           string(op.Outcome),
+		ErrorCode:         string(op.ErrorCode),
+		RedactedError:     op.RedactedError,
+	}
+}
+
+func parseLimit(r *http.Request, fallback int) int {
+	value := r.URL.Query().Get("limit")
+	if value == "" {
+		return fallback
+	}
+	limit, err := strconv.Atoi(value)
+	if err != nil || limit <= 0 {
+		return fallback
+	}
+	if limit > services.DefaultSyncHealthOperationLimit {
+		return services.DefaultSyncHealthOperationLimit
+	}
+	return limit
+}
+
+func writeJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
+}
+
+func writeJSONError(w http.ResponseWriter, status int, code string, message string) {
+	writeJSON(w, status, map[string]any{"error_code": code, "message": message})
+}

--- a/server/internal/api/sync_health_test.go
+++ b/server/internal/api/sync_health_test.go
@@ -26,7 +26,7 @@ func (f fakeAPIOperationLister) ListRecent(ctx context.Context, limit int) ([]*d
 
 func TestSyncHealthAPIUnknownWhenNoData(t *testing.T) {
 	handler := NewSyncHealthHandler(services.NewSyncHealthService(fakeAPIOperationLister{}, services.UnknownGreenSyncProvider()))
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/sync-health", nil)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rr := httptest.NewRecorder()
 
 	handler.Routes().ServeHTTP(rr, req)
@@ -70,7 +70,7 @@ func TestSyncHealthAPIOperationsAreRedacted(t *testing.T) {
 		RedactedError:     "ETag precondition failed.",
 	}}
 	handler := NewSyncHealthHandler(services.NewSyncHealthService(fakeAPIOperationLister{operations: ops}, services.UnknownGreenSyncProvider()))
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/sync-health/operations", nil)
+	req := httptest.NewRequest(http.MethodGet, "/operations", nil)
 	rr := httptest.NewRecorder()
 
 	handler.Routes().ServeHTTP(rr, req)
@@ -96,7 +96,7 @@ func TestSyncHealthAPIClients(t *testing.T) {
 		{OccurredAt: now.Add(-time.Minute), ClientFingerprint: domain.CalDAVClientAppleCalendar, Outcome: domain.CalDAVOperationSuccess},
 		{OccurredAt: now.Add(-2 * time.Minute), ClientFingerprint: domain.CalDAVClientThunderbird, Outcome: domain.CalDAVOperationSuccess},
 	}}, services.UnknownGreenSyncProvider()))
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/sync-health/clients", nil)
+	req := httptest.NewRequest(http.MethodGet, "/clients", nil)
 	rr := httptest.NewRecorder()
 
 	handler.Routes().ServeHTTP(rr, req)
@@ -115,7 +115,7 @@ func TestSyncHealthAPIClients(t *testing.T) {
 
 func TestSyncHealthValidationEndpointsPlaceholder(t *testing.T) {
 	handler := NewSyncHealthHandler(services.NewSyncHealthService(fakeAPIOperationLister{}, services.UnknownGreenSyncProvider()))
-	for _, path := range []string{"/api/v1/sync-health/validation-event/start", "/api/v1/sync-health/validation-event/verify"} {
+	for _, path := range []string{"/validation-event/start", "/validation-event/verify"} {
 		req := httptest.NewRequest(http.MethodPost, path, nil)
 		rr := httptest.NewRecorder()
 

--- a/server/internal/api/sync_health_test.go
+++ b/server/internal/api/sync_health_test.go
@@ -1,0 +1,131 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/airplne/calendar-app/server/internal/domain"
+	"github.com/airplne/calendar-app/server/internal/services"
+)
+
+type fakeAPIOperationLister struct {
+	operations []*domain.CalDAVOperation
+}
+
+func (f fakeAPIOperationLister) ListRecent(ctx context.Context, limit int) ([]*domain.CalDAVOperation, error) {
+	if limit > 0 && len(f.operations) > limit {
+		return f.operations[:limit], nil
+	}
+	return f.operations, nil
+}
+
+func TestSyncHealthAPIUnknownWhenNoData(t *testing.T) {
+	handler := NewSyncHealthHandler(services.NewSyncHealthService(fakeAPIOperationLister{}, services.UnknownGreenSyncProvider()))
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sync-health", nil)
+	rr := httptest.NewRecorder()
+
+	handler.Routes().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["status"] != string(domain.SyncHealthUnknown) {
+		t.Fatalf("status = %v, want unknown", body["status"])
+	}
+	if body["green_sync_completed"] != false {
+		t.Fatalf("green_sync_completed = %v, want false", body["green_sync_completed"])
+	}
+}
+
+func TestSyncHealthAPIOperationsAreRedacted(t *testing.T) {
+	privateFragments := []string{
+		"BEGIN:VCALENDAR",
+		"Sensitive Doctor Appointment",
+		"private-event-1",
+		"testuser",
+		"default",
+		"PrivateDeviceName",
+		"SecretBuildToken",
+	}
+	ops := []*domain.CalDAVOperation{{
+		OccurredAt:        time.Now().UTC(),
+		Method:            "PUT",
+		PathPattern:       "/dav/calendars/{principal}/{calendar}/{object}.ics",
+		StatusCode:        412,
+		DurationMillis:    20,
+		ClientFingerprint: domain.CalDAVClientFantastical,
+		ETagOutcome:       domain.CalDAVETagMismatched,
+		OperationKind:     domain.CalDAVOperationWrite,
+		Outcome:           domain.CalDAVOperationRecoverableFailure,
+		ErrorCode:         domain.CalDAVErrorETagConflict,
+		RedactedError:     "ETag precondition failed.",
+	}}
+	handler := NewSyncHealthHandler(services.NewSyncHealthService(fakeAPIOperationLister{operations: ops}, services.UnknownGreenSyncProvider()))
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sync-health/operations", nil)
+	rr := httptest.NewRecorder()
+
+	handler.Routes().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, string(domain.CalDAVClientFantastical)) {
+		t.Fatalf("response missing normalized fingerprint: %s", body)
+	}
+	for _, fragment := range privateFragments {
+		if strings.Contains(body, fragment) {
+			t.Fatalf("response leaked private fragment %q in %s", fragment, body)
+		}
+	}
+}
+
+func TestSyncHealthAPIClients(t *testing.T) {
+	now := time.Now().UTC()
+	handler := NewSyncHealthHandler(services.NewSyncHealthService(fakeAPIOperationLister{operations: []*domain.CalDAVOperation{
+		{OccurredAt: now, ClientFingerprint: domain.CalDAVClientAppleCalendar, Outcome: domain.CalDAVOperationSuccess},
+		{OccurredAt: now.Add(-time.Minute), ClientFingerprint: domain.CalDAVClientAppleCalendar, Outcome: domain.CalDAVOperationSuccess},
+		{OccurredAt: now.Add(-2 * time.Minute), ClientFingerprint: domain.CalDAVClientThunderbird, Outcome: domain.CalDAVOperationSuccess},
+	}}, services.UnknownGreenSyncProvider()))
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sync-health/clients", nil)
+	rr := httptest.NewRecorder()
+
+	handler.Routes().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "apple-calendar") || !strings.Contains(body, "Apple Calendar") {
+		t.Fatalf("response missing Apple Calendar client: %s", body)
+	}
+	if !strings.Contains(body, "thunderbird") || !strings.Contains(body, "Thunderbird") {
+		t.Fatalf("response missing Thunderbird client: %s", body)
+	}
+}
+
+func TestSyncHealthValidationEndpointsPlaceholder(t *testing.T) {
+	handler := NewSyncHealthHandler(services.NewSyncHealthService(fakeAPIOperationLister{}, services.UnknownGreenSyncProvider()))
+	for _, path := range []string{"/api/v1/sync-health/validation-event/start", "/api/v1/sync-health/validation-event/verify"} {
+		req := httptest.NewRequest(http.MethodPost, path, nil)
+		rr := httptest.NewRecorder()
+
+		handler.Routes().ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusNotImplemented {
+			t.Fatalf("%s status = %d, want 501; body=%s", path, rr.Code, rr.Body.String())
+		}
+		if !strings.Contains(rr.Body.String(), "green_sync_validation_not_implemented") {
+			t.Fatalf("%s response missing placeholder error: %s", path, rr.Body.String())
+		}
+	}
+}

--- a/server/internal/services/sync_health.go
+++ b/server/internal/services/sync_health.go
@@ -1,0 +1,263 @@
+package services
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	"github.com/airplne/calendar-app/server/internal/domain"
+)
+
+const DefaultSyncHealthOperationLimit = 50
+
+// CalDAVOperationLister is the read side needed from operation metadata storage.
+type CalDAVOperationLister interface {
+	ListRecent(ctx context.Context, limit int) ([]*domain.CalDAVOperation, error)
+}
+
+// GreenSyncProvider supplies the latest green-sync validation state. Issue #15
+// will replace the placeholder provider with persisted create/edit/delete state.
+type GreenSyncProvider interface {
+	Current(ctx context.Context) (domain.GreenSyncValidation, error)
+}
+
+type StaticGreenSyncProvider struct {
+	Validation domain.GreenSyncValidation
+}
+
+func (p StaticGreenSyncProvider) Current(ctx context.Context) (domain.GreenSyncValidation, error) {
+	return p.Validation, nil
+}
+
+func UnknownGreenSyncProvider() StaticGreenSyncProvider {
+	return StaticGreenSyncProvider{Validation: domain.GreenSyncValidation{Status: domain.GreenSyncNeverCompleted}}
+}
+
+type SyncHealthService struct {
+	operations CalDAVOperationLister
+	greenSync  GreenSyncProvider
+	evaluator   domain.SyncHealthEvaluator
+	limit       int
+}
+
+func NewSyncHealthService(operations CalDAVOperationLister, greenSync GreenSyncProvider) *SyncHealthService {
+	if greenSync == nil {
+		greenSync = UnknownGreenSyncProvider()
+	}
+	return &SyncHealthService{
+		operations: operations,
+		greenSync:  greenSync,
+		evaluator:  domain.NewDefaultSyncHealthEvaluator(),
+		limit:      DefaultSyncHealthOperationLimit,
+	}
+}
+
+func NewSyncHealthServiceWithEvaluator(operations CalDAVOperationLister, greenSync GreenSyncProvider, evaluator domain.SyncHealthEvaluator, limit int) *SyncHealthService {
+	if greenSync == nil {
+		greenSync = UnknownGreenSyncProvider()
+	}
+	if limit <= 0 {
+		limit = DefaultSyncHealthOperationLimit
+	}
+	return &SyncHealthService{operations: operations, greenSync: greenSync, evaluator: evaluator, limit: limit}
+}
+
+type SyncHealthSummary struct {
+	Health          domain.SyncHealth
+	GreenSync       domain.GreenSyncValidation
+	Operations      []*domain.CalDAVOperation
+	OperationCounts SyncOperationCounts
+	Latency         SyncLatency
+	Clients         []SyncClientSummary
+	LastSuccessAt   *time.Time
+	LastFailureAt   *time.Time
+}
+
+type SyncOperationCounts struct {
+	Total                int
+	Success              int
+	Failure              int
+	ETagConflicts        int
+	DuplicateUIDAttempts int
+	ParseFailures        int
+	CorruptICSIncidents  int
+	WriteFailures        int
+}
+
+type SyncLatency struct {
+	MedianMillis int64
+	P95Millis    int64
+}
+
+type SyncClientSummary struct {
+	Fingerprint       string
+	DisplayName       string
+	LastSeenAt        time.Time
+	OperationCount    int
+	OperationCount24h int
+}
+
+func (s *SyncHealthService) Summary(ctx context.Context) (*SyncHealthSummary, error) {
+	operations, err := s.operations.ListRecent(ctx, s.limit)
+	if err != nil {
+		return nil, err
+	}
+	greenSync, err := s.greenSync.Current(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	health := s.evaluator.Evaluate(domain.SyncHealthEvaluationInput{
+		Now:        time.Now().UTC(),
+		GreenSync:  greenSync,
+		Operations: domain.SummarizeCalDAVOperations(operations),
+	})
+
+	return &SyncHealthSummary{
+		Health:          health,
+		GreenSync:       greenSync,
+		Operations:      operations,
+		OperationCounts: CountOperations(operations),
+		Latency:         ComputeLatency(operations),
+		Clients:         SummarizeClients(operations, time.Now().UTC().Add(-24*time.Hour)),
+		LastSuccessAt:   lastOperationTime(operations, true),
+		LastFailureAt:   lastOperationTime(operations, false),
+	}, nil
+}
+
+func (s *SyncHealthService) RecentOperations(ctx context.Context, limit int) ([]*domain.CalDAVOperation, error) {
+	if limit <= 0 || limit > s.limit {
+		limit = s.limit
+	}
+	return s.operations.ListRecent(ctx, limit)
+}
+
+func (s *SyncHealthService) Clients(ctx context.Context) ([]SyncClientSummary, error) {
+	operations, err := s.operations.ListRecent(ctx, s.limit)
+	if err != nil {
+		return nil, err
+	}
+	return SummarizeClients(operations, time.Now().UTC().Add(-24*time.Hour)), nil
+}
+
+func CountOperations(operations []*domain.CalDAVOperation) SyncOperationCounts {
+	counts := SyncOperationCounts{Total: len(operations)}
+	for _, op := range operations {
+		if op == nil {
+			continue
+		}
+		if op.Outcome == domain.CalDAVOperationSuccess {
+			counts.Success++
+		} else {
+			counts.Failure++
+		}
+		if op.IsETagConflict() {
+			counts.ETagConflicts++
+		}
+		if op.ErrorCode == domain.CalDAVErrorDuplicateUID {
+			counts.DuplicateUIDAttempts++
+		}
+		if op.ErrorCode == domain.CalDAVErrorParse {
+			counts.ParseFailures++
+		}
+		if op.ErrorCode == domain.CalDAVErrorCorruptICS {
+			counts.CorruptICSIncidents++
+		}
+		if op.IsWriteFailure() {
+			counts.WriteFailures++
+		}
+	}
+	return counts
+}
+
+func ComputeLatency(operations []*domain.CalDAVOperation) SyncLatency {
+	if len(operations) == 0 {
+		return SyncLatency{}
+	}
+	durations := make([]int64, 0, len(operations))
+	for _, op := range operations {
+		if op != nil {
+			durations = append(durations, op.DurationMillis)
+		}
+	}
+	if len(durations) == 0 {
+		return SyncLatency{}
+	}
+	sort.Slice(durations, func(i, j int) bool { return durations[i] < durations[j] })
+	return SyncLatency{MedianMillis: percentile(durations, 50), P95Millis: percentile(durations, 95)}
+}
+
+func SummarizeClients(operations []*domain.CalDAVOperation, since time.Time) []SyncClientSummary {
+	byClient := map[string]*SyncClientSummary{}
+	for _, op := range operations {
+		if op == nil || op.ClientFingerprint == "" {
+			continue
+		}
+		client := byClient[op.ClientFingerprint]
+		if client == nil {
+			client = &SyncClientSummary{Fingerprint: op.ClientFingerprint, DisplayName: DisplayNameForClient(op.ClientFingerprint)}
+			byClient[op.ClientFingerprint] = client
+		}
+		client.OperationCount++
+		if !op.OccurredAt.Before(since) {
+			client.OperationCount24h++
+		}
+		if client.LastSeenAt.IsZero() || op.OccurredAt.After(client.LastSeenAt) {
+			client.LastSeenAt = op.OccurredAt
+		}
+	}
+
+	clients := make([]SyncClientSummary, 0, len(byClient))
+	for _, client := range byClient {
+		clients = append(clients, *client)
+	}
+	sort.Slice(clients, func(i, j int) bool { return clients[i].LastSeenAt.After(clients[j].LastSeenAt) })
+	return clients
+}
+
+func DisplayNameForClient(fingerprint string) string {
+	switch fingerprint {
+	case domain.CalDAVClientAppleCalendar:
+		return "Apple Calendar"
+	case domain.CalDAVClientFantastical:
+		return "Fantastical"
+	case domain.CalDAVClientDAVx5:
+		return "DAVx5"
+	case domain.CalDAVClientThunderbird:
+		return "Thunderbird"
+	default:
+		return "Unknown CalDAV client"
+	}
+}
+
+func lastOperationTime(operations []*domain.CalDAVOperation, success bool) *time.Time {
+	for _, op := range operations {
+		if op == nil {
+			continue
+		}
+		if success && op.Outcome == domain.CalDAVOperationSuccess {
+			return &op.OccurredAt
+		}
+		if !success && op.Outcome != domain.CalDAVOperationSuccess {
+			return &op.OccurredAt
+		}
+	}
+	return nil
+}
+
+func percentile(sorted []int64, pct int) int64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	if len(sorted) == 1 {
+		return sorted[0]
+	}
+	idx := (pct*(len(sorted)-1) + 99) / 100
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(sorted) {
+		idx = len(sorted) - 1
+	}
+	return sorted[idx]
+}

--- a/server/internal/services/sync_health_test.go
+++ b/server/internal/services/sync_health_test.go
@@ -1,0 +1,155 @@
+package services
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/airplne/calendar-app/server/internal/domain"
+)
+
+type fakeOperationLister struct {
+	operations []*domain.CalDAVOperation
+}
+
+func (f fakeOperationLister) ListRecent(ctx context.Context, limit int) ([]*domain.CalDAVOperation, error) {
+	if limit > 0 && len(f.operations) > limit {
+		return f.operations[:limit], nil
+	}
+	return f.operations, nil
+}
+
+func TestSyncHealthServiceUnknownWithNoDataAndNoGreenSync(t *testing.T) {
+	service := NewSyncHealthService(fakeOperationLister{}, UnknownGreenSyncProvider())
+
+	summary, err := service.Summary(context.Background())
+	if err != nil {
+		t.Fatalf("Summary() error = %v", err)
+	}
+
+	if summary.Health.Status != domain.SyncHealthUnknown {
+		t.Fatalf("status = %q, want unknown", summary.Health.Status)
+	}
+	assertReason(t, summary.Health.Reasons, domain.SyncHealthReasonGreenSyncNotCompleted)
+	assertReason(t, summary.Health.Reasons, domain.SyncHealthReasonNoRecentOperationData)
+}
+
+func TestSyncHealthServiceHealthyWithPassedGreenSyncAndSuccessfulOperation(t *testing.T) {
+	now := time.Now().UTC()
+	service := NewSyncHealthService(
+		fakeOperationLister{operations: []*domain.CalDAVOperation{{
+			OccurredAt:        now,
+			Method:            "GET",
+			StatusCode:        200,
+			DurationMillis:    12,
+			ClientFingerprint: domain.CalDAVClientAppleCalendar,
+			OperationKind:     domain.CalDAVOperationRead,
+			Outcome:           domain.CalDAVOperationSuccess,
+		}}},
+		StaticGreenSyncProvider{Validation: passedGreenSync(now)},
+	)
+
+	summary, err := service.Summary(context.Background())
+	if err != nil {
+		t.Fatalf("Summary() error = %v", err)
+	}
+	if summary.Health.Status != domain.SyncHealthHealthy {
+		t.Fatalf("status = %q, want healthy; reasons=%+v", summary.Health.Status, summary.Health.Reasons)
+	}
+	if summary.OperationCounts.Success != 1 || summary.OperationCounts.Total != 1 {
+		t.Fatalf("counts = %+v", summary.OperationCounts)
+	}
+	if len(summary.Clients) != 1 || summary.Clients[0].Fingerprint != domain.CalDAVClientAppleCalendar {
+		t.Fatalf("clients = %+v", summary.Clients)
+	}
+}
+
+func TestSyncHealthServiceWarningForETagConflicts(t *testing.T) {
+	now := time.Now().UTC()
+	ops := make([]*domain.CalDAVOperation, 0, 6)
+	for i := 0; i < 6; i++ {
+		ops = append(ops, &domain.CalDAVOperation{
+			OccurredAt:        now.Add(time.Duration(-i) * time.Minute),
+			Method:            "PUT",
+			StatusCode:        412,
+			ClientFingerprint: domain.CalDAVClientFantastical,
+			ETagOutcome:       domain.CalDAVETagMismatched,
+			OperationKind:     domain.CalDAVOperationWrite,
+			Outcome:           domain.CalDAVOperationRecoverableFailure,
+			ErrorCode:         domain.CalDAVErrorETagConflict,
+		})
+	}
+	service := NewSyncHealthService(fakeOperationLister{operations: ops}, StaticGreenSyncProvider{Validation: passedGreenSync(now)})
+
+	summary, err := service.Summary(context.Background())
+	if err != nil {
+		t.Fatalf("Summary() error = %v", err)
+	}
+	if summary.Health.Status != domain.SyncHealthWarning {
+		t.Fatalf("status = %q, want warning; reasons=%+v", summary.Health.Status, summary.Health.Reasons)
+	}
+	if summary.OperationCounts.ETagConflicts != 6 {
+		t.Fatalf("ETagConflicts = %d, want 6", summary.OperationCounts.ETagConflicts)
+	}
+	assertReason(t, summary.Health.Reasons, domain.SyncHealthReasonETagConflictThreshold)
+}
+
+func TestSyncHealthServiceCriticalForCorruptICSAndDuplicateUID(t *testing.T) {
+	now := time.Now().UTC()
+	service := NewSyncHealthService(
+		fakeOperationLister{operations: []*domain.CalDAVOperation{
+			{
+				OccurredAt:        now,
+				Method:            "GET",
+				StatusCode:        500,
+				ClientFingerprint: domain.CalDAVClientDAVx5,
+				OperationKind:     domain.CalDAVOperationRead,
+				Outcome:           domain.CalDAVOperationIntegrityFailure,
+				ErrorCode:         domain.CalDAVErrorCorruptICS,
+			},
+			{
+				OccurredAt:        now.Add(-time.Minute),
+				Method:            "PUT",
+				StatusCode:        409,
+				ClientFingerprint: domain.CalDAVClientDAVx5,
+				OperationKind:     domain.CalDAVOperationWrite,
+				Outcome:           domain.CalDAVOperationIntegrityFailure,
+				ErrorCode:         domain.CalDAVErrorDuplicateUID,
+			},
+		}},
+		StaticGreenSyncProvider{Validation: passedGreenSync(now)},
+	)
+
+	summary, err := service.Summary(context.Background())
+	if err != nil {
+		t.Fatalf("Summary() error = %v", err)
+	}
+	if summary.Health.Status != domain.SyncHealthCritical {
+		t.Fatalf("status = %q, want critical; reasons=%+v", summary.Health.Status, summary.Health.Reasons)
+	}
+	if summary.OperationCounts.CorruptICSIncidents != 1 || summary.OperationCounts.DuplicateUIDAttempts != 1 {
+		t.Fatalf("counts = %+v", summary.OperationCounts)
+	}
+	assertReason(t, summary.Health.Reasons, domain.SyncHealthReasonCorruptICSDetected)
+	assertReason(t, summary.Health.Reasons, domain.SyncHealthReasonDuplicateUIDUnresolved)
+}
+
+func passedGreenSync(completedAt time.Time) domain.GreenSyncValidation {
+	return domain.GreenSyncValidation{
+		Status:           domain.GreenSyncPassed,
+		CompletedAt:      &completedAt,
+		CreateStepPassed: true,
+		EditStepPassed:   true,
+		DeleteStepPassed: true,
+	}
+}
+
+func assertReason(t *testing.T, reasons []domain.SyncHealthReason, code string) {
+	t.Helper()
+	for _, reason := range reasons {
+		if reason.Code == code {
+			return
+		}
+	}
+	t.Fatalf("expected reason %q in %+v", code, reasons)
+}


### PR DESCRIPTION
## Summary

Implements issue #13 by adding the backend Sync Health API using the Sync Health evaluator from #11 and CalDAV operation metadata from #12.

Closes #13.

## Scope

- Adds Sync Health service/API endpoint.
- Summarizes recent CalDAV operation metadata.
- Returns current sync health status and reasons.
- Returns redacted recent operation metadata.
- Returns normalized client summaries.
- Excludes raw ICS, raw user-agent, event content, task content, LLM context, and Todoist data.

## Green-sync validation

Full create/edit/delete validation is owned by #15. This PR exposes placeholder validation endpoints that return `501 not_implemented` and reports green sync as incomplete/unknown by default.

## Non-goals

- Does not implement debug bundle export.
- Does not implement onboarding green-sync UI/API.
- Does not implement frontend Sync Health dashboard.
- Does not add LLM or Todoist behavior.
- Does not add app-specific CalDAV passwords.

## Tests

- [ ] `cd server && go test ./...`
