### PR TITLE
Build redacted debug bundle export

### DIFF
--- a/server/cmd/calendarapp/main.go
+++ b/server/cmd/calendarapp/main.go
@@ -135,6 +135,17 @@ func main() {
 	syncHealthService := services.NewSyncHealthService(operationRepo, services.UnknownGreenSyncProvider())
 	r.Mount("/api/v1/sync-health", api.NewSyncHealthHandler(syncHealthService).Routes())
 
+	// Authenticated debug bundle export. This reuses MVP Basic Auth/env credentials as local admin access.
+	debugBundleService := services.NewDebugBundleService(syncHealthService, services.DebugBundleOptions{
+		Version:       getEnv("CALENDARAPP_VERSION", "unknown"),
+		Environment:   appEnv,
+		DataDir:       dataDir,
+		MigrationsDir: migrationsDir,
+		GeneratedBy:   authConfig.Username,
+	})
+	debugBundleHandler := caldav.BasicAuthMiddleware(authConfig, userRepo)(api.NewDebugBundleHandler(debugBundleService))
+	r.Handle("/api/v1/debug-bundle", debugBundleHandler)
+
 	// Well-known CalDAV auto-discovery endpoint
 	r.Get("/.well-known/caldav", caldav.NewWellKnownRoutes(authConfig.Username).ServeHTTP)
 

--- a/server/cmd/calendarapp/main.go
+++ b/server/cmd/calendarapp/main.go
@@ -141,7 +141,6 @@ func main() {
 		Environment:   appEnv,
 		DataDir:       dataDir,
 		MigrationsDir: migrationsDir,
-		GeneratedBy:   authConfig.Username,
 	})
 	debugBundleHandler := caldav.BasicAuthMiddleware(authConfig, userRepo)(api.NewDebugBundleHandler(debugBundleService))
 	r.Handle("/api/v1/debug-bundle", debugBundleHandler)

--- a/server/internal/api/debug_bundle.go
+++ b/server/internal/api/debug_bundle.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/airplne/calendar-app/server/internal/services"
+)
+
+type DebugBundleHandler struct {
+	service *services.DebugBundleService
+}
+
+func NewDebugBundleHandler(service *services.DebugBundleService) *DebugBundleHandler {
+	return &DebugBundleHandler{service: service}
+}
+
+func (h *DebugBundleHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed.")
+		return
+	}
+	bundle, err := h.service.Build(r.Context())
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "debug_bundle_unavailable", "Debug bundle is unavailable.")
+		return
+	}
+
+	actor := bundle.GeneratedBy
+	if actor == "" {
+		actor = "authenticated-user"
+	}
+	slog.Info("debug_bundle.exported", "timestamp", time.Now().UTC(), "actor", actor, "redaction_mode", bundle.Redaction.Mode)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Disposition", `attachment; filename="calendar-app-debug-bundle.json"`)
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(bundle)
+}

--- a/server/internal/api/debug_bundle.go
+++ b/server/internal/api/debug_bundle.go
@@ -28,11 +28,7 @@ func (h *DebugBundleHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	actor := bundle.GeneratedBy
-	if actor == "" {
-		actor = "authenticated-user"
-	}
-	slog.Info("debug_bundle.exported", "timestamp", time.Now().UTC(), "actor", actor, "redaction_mode", bundle.Redaction.Mode)
+	slog.Info("debug_bundle.exported", "timestamp", time.Now().UTC(), "actor", "authenticated-user", "redaction_mode", bundle.Redaction.Mode)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Content-Disposition", `attachment; filename="calendar-app-debug-bundle.json"`)

--- a/server/internal/api/debug_bundle_test.go
+++ b/server/internal/api/debug_bundle_test.go
@@ -42,6 +42,42 @@ func TestDebugBundleAPIRequiresBasicAuth(t *testing.T) {
 	}
 }
 
+func TestDebugBundleAPIRejectsWrongBasicAuthCredentials(t *testing.T) {
+	handler := authenticatedDebugBundleHandler(fakeDebugAPIOperationLister{})
+	cases := []struct {
+		name     string
+		username string
+		password string
+	}{
+		{name: "correct username wrong password", username: "admin", password: "wrong-password-value"},
+		{name: "wrong username correct password", username: "private-admin-user", password: "secret-password-value"},
+		{name: "wrong username wrong password", username: "local-principal", password: "wrong-password-value"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/debug-bundle", nil)
+			req.SetBasicAuth(tc.username, tc.password)
+			rr := httptest.NewRecorder()
+
+			handler.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusUnauthorized {
+				t.Fatalf("status = %d, want 401; body=%s", rr.Code, rr.Body.String())
+			}
+			body := rr.Body.String()
+			if strings.Contains(body, "schema_version") || strings.Contains(body, services.DebugBundleSchemaVersion) {
+				t.Fatalf("wrong credentials returned debug bundle payload: %s", body)
+			}
+			for _, fragment := range []string{tc.username, tc.password, "wrong-password-value", "secret-password-value"} {
+				if strings.Contains(body, fragment) {
+					t.Fatalf("wrong-credential response leaked credential fragment %q in %s", fragment, body)
+				}
+			}
+		})
+	}
+}
+
 func TestDebugBundleAPIReturnsRedactedBundle(t *testing.T) {
 	handler := authenticatedDebugBundleHandler(fakeDebugAPIOperationLister{operations: []*domain.CalDAVOperation{{
 		OccurredAt:        time.Now().UTC(),
@@ -57,7 +93,7 @@ func TestDebugBundleAPIReturnsRedactedBundle(t *testing.T) {
 		RedactedError:     "ETag precondition failed.",
 	}}})
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/debug-bundle", nil)
-	req.SetBasicAuth("admin", "secret")
+	req.SetBasicAuth("admin", "secret-password-value")
 	rr := httptest.NewRecorder()
 
 	handler.ServeHTTP(rr, req)
@@ -73,16 +109,21 @@ func TestDebugBundleAPIReturnsRedactedBundle(t *testing.T) {
 	}
 
 	body := rr.Body.String()
+	if strings.Contains(body, "generated_by") {
+		t.Fatalf("debug bundle should not include generated_by: %s", body)
+	}
 	for _, fragment := range []string{
 		"BEGIN:VCALENDAR",
 		"Sensitive Doctor Appointment",
 		"Detailed private description",
 		"attendee@example.com",
 		"private-event-1",
+		"private-admin-user",
+		"local-principal",
 		"PrivateDeviceName",
 		"SecretBuildToken",
 		"Authorization",
-		"secret",
+		"secret-password-value",
 	} {
 		if strings.Contains(body, fragment) {
 			t.Fatalf("debug bundle leaked private fragment %q in %s", fragment, body)
@@ -110,7 +151,7 @@ func TestDebugBundleAPIReturnsRedactedBundle(t *testing.T) {
 func TestDebugBundleAPIReturnsSafeGenericError(t *testing.T) {
 	handler := authenticatedDebugBundleHandler(fakeDebugAPIOperationLister{err: errors.New("database failed for private-event-1 BEGIN:VCALENDAR")})
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/debug-bundle", nil)
-	req.SetBasicAuth("admin", "secret")
+	req.SetBasicAuth("admin", "secret-password-value")
 	rr := httptest.NewRecorder()
 
 	handler.ServeHTTP(rr, req)
@@ -131,8 +172,8 @@ func TestDebugBundleAPIReturnsSafeGenericError(t *testing.T) {
 
 func authenticatedDebugBundleHandler(lister fakeDebugAPIOperationLister) http.Handler {
 	syncService := services.NewSyncHealthService(lister, services.UnknownGreenSyncProvider())
-	debugService := services.NewDebugBundleService(syncService, services.DebugBundleOptions{Version: "test", Environment: "test", GeneratedBy: "admin"})
-	return caldav.BasicAuthMiddleware(caldav.AuthConfig{Username: "admin", Password: "secret"}, fakeDebugUserRepo{})(NewDebugBundleHandler(debugService))
+	debugService := services.NewDebugBundleService(syncService, services.DebugBundleOptions{Version: "test", Environment: "test"})
+	return caldav.BasicAuthMiddleware(caldav.AuthConfig{Username: "admin", Password: "secret-password-value"}, fakeDebugUserRepo{})(NewDebugBundleHandler(debugService))
 }
 
 type fakeDebugUserRepo struct{}

--- a/server/internal/api/debug_bundle_test.go
+++ b/server/internal/api/debug_bundle_test.go
@@ -1,0 +1,153 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/airplne/calendar-app/server/internal/caldav"
+	"github.com/airplne/calendar-app/server/internal/domain"
+	"github.com/airplne/calendar-app/server/internal/services"
+)
+
+type fakeDebugAPIOperationLister struct {
+	operations []*domain.CalDAVOperation
+	err        error
+}
+
+func (f fakeDebugAPIOperationLister) ListRecent(ctx context.Context, limit int) ([]*domain.CalDAVOperation, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	if limit > 0 && len(f.operations) > limit {
+		return f.operations[:limit], nil
+	}
+	return f.operations, nil
+}
+
+func TestDebugBundleAPIRequiresBasicAuth(t *testing.T) {
+	handler := authenticatedDebugBundleHandler(fakeDebugAPIOperationLister{})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/debug-bundle", nil)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rr.Code)
+	}
+}
+
+func TestDebugBundleAPIReturnsRedactedBundle(t *testing.T) {
+	handler := authenticatedDebugBundleHandler(fakeDebugAPIOperationLister{operations: []*domain.CalDAVOperation{{
+		OccurredAt:        time.Now().UTC(),
+		Method:            "PUT",
+		PathPattern:       "/dav/calendars/{principal}/{calendar}/{object}.ics",
+		StatusCode:        412,
+		DurationMillis:    10,
+		ClientFingerprint: domain.CalDAVClientDAVx5,
+		ETagOutcome:       domain.CalDAVETagMismatched,
+		OperationKind:     domain.CalDAVOperationWrite,
+		Outcome:           domain.CalDAVOperationRecoverableFailure,
+		ErrorCode:         domain.CalDAVErrorETagConflict,
+		RedactedError:     "ETag precondition failed.",
+	}}})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/debug-bundle", nil)
+	req.SetBasicAuth("admin", "secret")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	if ct := rr.Header().Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Fatalf("content-type = %q, want application/json", ct)
+	}
+	if cd := rr.Header().Get("Content-Disposition"); !strings.Contains(cd, "calendar-app-debug-bundle.json") {
+		t.Fatalf("content-disposition = %q", cd)
+	}
+
+	body := rr.Body.String()
+	for _, fragment := range []string{
+		"BEGIN:VCALENDAR",
+		"Sensitive Doctor Appointment",
+		"Detailed private description",
+		"attendee@example.com",
+		"private-event-1",
+		"PrivateDeviceName",
+		"SecretBuildToken",
+		"Authorization",
+		"secret",
+	} {
+		if strings.Contains(body, fragment) {
+			t.Fatalf("debug bundle leaked private fragment %q in %s", fragment, body)
+		}
+	}
+
+	var bundle services.DebugBundle
+	if err := json.Unmarshal(rr.Body.Bytes(), &bundle); err != nil {
+		t.Fatalf("decode bundle: %v", err)
+	}
+	if bundle.SchemaVersion != services.DebugBundleSchemaVersion {
+		t.Fatalf("schema_version = %q", bundle.SchemaVersion)
+	}
+	if bundle.Redaction.RawICSIncluded || bundle.Redaction.RawUserAgentIncluded || bundle.Redaction.SecretsIncluded {
+		t.Fatalf("unexpected redaction flags: %+v", bundle.Redaction)
+	}
+	if len(bundle.CalDAV.RecentOperations) != 1 {
+		t.Fatalf("recent operations = %d, want 1", len(bundle.CalDAV.RecentOperations))
+	}
+	if bundle.CalDAV.RecentOperations[0].ClientFingerprint != domain.CalDAVClientDAVx5 {
+		t.Fatalf("client fingerprint = %q", bundle.CalDAV.RecentOperations[0].ClientFingerprint)
+	}
+}
+
+func TestDebugBundleAPIReturnsSafeGenericError(t *testing.T) {
+	handler := authenticatedDebugBundleHandler(fakeDebugAPIOperationLister{err: errors.New("database failed for private-event-1 BEGIN:VCALENDAR")})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/debug-bundle", nil)
+	req.SetBasicAuth("admin", "secret")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rr.Code)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "debug_bundle_unavailable") {
+		t.Fatalf("body missing safe error code: %s", body)
+	}
+	for _, fragment := range []string{"private-event-1", "BEGIN:VCALENDAR", "database failed"} {
+		if strings.Contains(body, fragment) {
+			t.Fatalf("error response leaked private fragment %q in %s", fragment, body)
+		}
+	}
+}
+
+func authenticatedDebugBundleHandler(lister fakeDebugAPIOperationLister) http.Handler {
+	syncService := services.NewSyncHealthService(lister, services.UnknownGreenSyncProvider())
+	debugService := services.NewDebugBundleService(syncService, services.DebugBundleOptions{Version: "test", Environment: "test", GeneratedBy: "admin"})
+	return caldav.BasicAuthMiddleware(caldav.AuthConfig{Username: "admin", Password: "secret"}, fakeDebugUserRepo{})(NewDebugBundleHandler(debugService))
+}
+
+type fakeDebugUserRepo struct{}
+
+func (fakeDebugUserRepo) Create(ctx context.Context, username string) (*domain.User, error) {
+	return &domain.User{ID: 1, Username: username}, nil
+}
+
+func (fakeDebugUserRepo) GetByID(ctx context.Context, id int64) (*domain.User, error) {
+	return &domain.User{ID: id, Username: "admin"}, nil
+}
+
+func (fakeDebugUserRepo) GetByUsername(ctx context.Context, username string) (*domain.User, error) {
+	if username != "admin" {
+		return nil, domain.ErrNotFound
+	}
+	return &domain.User{ID: 1, Username: username}, nil
+}

--- a/server/internal/services/debug_bundle.go
+++ b/server/internal/services/debug_bundle.go
@@ -1,0 +1,239 @@
+package services
+
+import (
+	"context"
+	"os"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/airplne/calendar-app/server/internal/domain"
+)
+
+const DebugBundleSchemaVersion = "debug_bundle.v1"
+
+type DebugBundleService struct {
+	syncHealth *SyncHealthService
+	options    DebugBundleOptions
+}
+
+type DebugBundleOptions struct {
+	Version       string
+	Environment   string
+	DataDir       string
+	MigrationsDir string
+	GeneratedBy   string
+}
+
+type DebugBundle struct {
+	SchemaVersion string                 `json:"schema_version"`
+	GeneratedAt   time.Time              `json:"generated_at"`
+	GeneratedBy   string                 `json:"generated_by,omitempty"`
+	Redaction     DebugBundleRedaction   `json:"redaction"`
+	Server        DebugBundleServer      `json:"server"`
+	Config        DebugBundleConfig      `json:"config"`
+	Runtime       DebugBundleRuntime     `json:"runtime"`
+	SyncHealth    DebugBundleSyncHealth  `json:"sync_health"`
+	CalDAV        DebugBundleCalDAV      `json:"caldav"`
+	ErrorTraces   []DebugBundleErrorItem `json:"error_traces"`
+	Notes         []string               `json:"notes"`
+}
+
+type DebugBundleRedaction struct {
+	Mode                 string `json:"mode"`
+	RawICSIncluded       bool   `json:"raw_ics_included"`
+	RawUserAgentIncluded bool   `json:"raw_user_agent_included"`
+	SecretsIncluded      bool   `json:"secrets_included"`
+}
+
+type DebugBundleServer struct {
+	Version     string `json:"version"`
+	Environment string `json:"environment"`
+}
+
+type DebugBundleConfig struct {
+	DataDirConfigured       bool     `json:"data_dir_configured"`
+	MigrationsDirConfigured bool     `json:"migrations_dir_configured"`
+	AuthMode                string   `json:"auth_mode"`
+	SecretsRedacted         []string `json:"secrets_redacted"`
+}
+
+type DebugBundleRuntime struct {
+	GoVersion string `json:"go_version"`
+	GOOS      string `json:"goos"`
+	GOARCH    string `json:"goarch"`
+}
+
+type DebugBundleSyncHealth struct {
+	Status             string                     `json:"status"`
+	EvaluatedAt         time.Time                  `json:"evaluated_at"`
+	Reasons             []DebugBundleReason        `json:"reasons"`
+	GreenSyncCompleted bool                       `json:"green_sync_completed"`
+	GreenSyncState     string                     `json:"green_sync_state"`
+	OperationCounts    SyncOperationCounts         `json:"operation_counts"`
+	Latency            SyncLatency                 `json:"latency_ms"`
+	Clients            []SyncClientSummary         `json:"clients"`
+}
+
+type DebugBundleReason struct {
+	Code     string `json:"code"`
+	Severity string `json:"severity"`
+	Message  string `json:"message"`
+}
+
+type DebugBundleCalDAV struct {
+	RecentOperations []DebugBundleOperation `json:"recent_operations"`
+	ClientSummaries  []SyncClientSummary    `json:"client_summaries"`
+}
+
+type DebugBundleOperation struct {
+	OccurredAt        time.Time `json:"occurred_at"`
+	Method            string    `json:"method"`
+	PathPattern       string    `json:"path_pattern"`
+	StatusCode        int       `json:"status_code"`
+	DurationMillis    int64     `json:"duration_ms"`
+	ClientFingerprint string    `json:"client_fingerprint"`
+	ETagOutcome       string    `json:"etag_outcome"`
+	OperationKind     string    `json:"operation_kind"`
+	Outcome           string    `json:"outcome"`
+	ErrorCode         string    `json:"error_code,omitempty"`
+	RedactedError     string    `json:"redacted_error,omitempty"`
+}
+
+type DebugBundleErrorItem struct {
+	OccurredAt        time.Time `json:"occurred_at"`
+	ClientFingerprint string    `json:"client_fingerprint"`
+	Method            string    `json:"method"`
+	StatusCode        int       `json:"status_code"`
+	ErrorCode         string    `json:"error_code"`
+	RedactedError     string    `json:"redacted_error"`
+}
+
+func NewDebugBundleService(syncHealth *SyncHealthService, options DebugBundleOptions) *DebugBundleService {
+	if options.Version == "" {
+		options.Version = "unknown"
+	}
+	if options.Environment == "" {
+		options.Environment = "self-hosted"
+	}
+	return &DebugBundleService{syncHealth: syncHealth, options: options}
+}
+
+func (s *DebugBundleService) Build(ctx context.Context) (*DebugBundle, error) {
+	summary, err := s.syncHealth.Summary(ctx)
+	if err != nil {
+		return nil, err
+	}
+	operations, err := s.syncHealth.RecentOperations(ctx, DefaultSyncHealthOperationLimit)
+	if err != nil {
+		return nil, err
+	}
+
+	bundle := &DebugBundle{
+		SchemaVersion: DebugBundleSchemaVersion,
+		GeneratedAt:   time.Now().UTC(),
+		GeneratedBy:   s.options.GeneratedBy,
+		Redaction: DebugBundleRedaction{
+			Mode:                 "default",
+			RawICSIncluded:       false,
+			RawUserAgentIncluded: false,
+			SecretsIncluded:      false,
+		},
+		Server: DebugBundleServer{Version: s.options.Version, Environment: s.options.Environment},
+		Config: DebugBundleConfig{
+			DataDirConfigured:       s.options.DataDir != "",
+			MigrationsDirConfigured: s.options.MigrationsDir != "",
+			AuthMode:                "basic_auth_env_credentials",
+			SecretsRedacted:         RedactedSecretNames(),
+		},
+		Runtime: DebugBundleRuntime{GoVersion: runtime.Version(), GOOS: runtime.GOOS, GOARCH: runtime.GOARCH},
+		SyncHealth: DebugBundleSyncHealth{
+			Status:             string(summary.Health.Status),
+			EvaluatedAt:         summary.Health.EvaluatedAt,
+			Reasons:             toDebugBundleReasons(summary.Health.Reasons),
+			GreenSyncCompleted: summary.Health.GreenSyncCompleted,
+			GreenSyncState:     string(summary.Health.LastValidationState),
+			OperationCounts:    summary.OperationCounts,
+			Latency:            summary.Latency,
+			Clients:            summary.Clients,
+		},
+		CalDAV: DebugBundleCalDAV{
+			RecentOperations: toDebugBundleOperations(operations),
+			ClientSummaries:  summary.Clients,
+		},
+		ErrorTraces: toDebugBundleErrors(operations),
+		Notes: []string{
+			"Default debug bundles contain redacted metadata only.",
+			"Raw ICS, event descriptions, attendees, raw user-agents, tokens, passwords, LLM context, and Todoist data are excluded.",
+			"Green-sync validation remains incomplete until issue #15 implements the create/edit/delete validation flow.",
+		},
+	}
+	return bundle, nil
+}
+
+func toDebugBundleReasons(reasons []domain.SyncHealthReason) []DebugBundleReason {
+	out := make([]DebugBundleReason, 0, len(reasons))
+	for _, reason := range reasons {
+		out = append(out, DebugBundleReason{Code: reason.Code, Severity: string(reason.Severity), Message: reason.Message})
+	}
+	return out
+}
+
+func toDebugBundleOperations(operations []*domain.CalDAVOperation) []DebugBundleOperation {
+	out := make([]DebugBundleOperation, 0, len(operations))
+	for _, op := range operations {
+		if op == nil {
+			continue
+		}
+		out = append(out, DebugBundleOperation{
+			OccurredAt:        op.OccurredAt,
+			Method:            op.Method,
+			PathPattern:       op.PathPattern,
+			StatusCode:        op.StatusCode,
+			DurationMillis:    op.DurationMillis,
+			ClientFingerprint: op.ClientFingerprint,
+			ETagOutcome:       string(op.ETagOutcome),
+			OperationKind:     string(op.OperationKind),
+			Outcome:           string(op.Outcome),
+			ErrorCode:         string(op.ErrorCode),
+			RedactedError:     op.RedactedError,
+		})
+	}
+	return out
+}
+
+func toDebugBundleErrors(operations []*domain.CalDAVOperation) []DebugBundleErrorItem {
+	items := make([]DebugBundleErrorItem, 0)
+	for _, op := range operations {
+		if op == nil || op.Outcome == domain.CalDAVOperationSuccess {
+			continue
+		}
+		items = append(items, DebugBundleErrorItem{
+			OccurredAt:        op.OccurredAt,
+			ClientFingerprint: op.ClientFingerprint,
+			Method:            op.Method,
+			StatusCode:        op.StatusCode,
+			ErrorCode:         string(op.ErrorCode),
+			RedactedError:     op.RedactedError,
+		})
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i].OccurredAt.After(items[j].OccurredAt) })
+	return items
+}
+
+func RedactedSecretNames() []string {
+	names := []string{}
+	for _, pair := range os.Environ() {
+		name := pair
+		if idx := strings.Index(pair, "="); idx >= 0 {
+			name = pair[:idx]
+		}
+		upper := strings.ToUpper(name)
+		if strings.Contains(upper, "PASS") || strings.Contains(upper, "PASSWORD") || strings.Contains(upper, "TOKEN") || strings.Contains(upper, "SECRET") || strings.Contains(upper, "KEY") || strings.Contains(upper, "AUTH") {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}

--- a/server/internal/services/debug_bundle.go
+++ b/server/internal/services/debug_bundle.go
@@ -23,13 +23,11 @@ type DebugBundleOptions struct {
 	Environment   string
 	DataDir       string
 	MigrationsDir string
-	GeneratedBy   string
 }
 
 type DebugBundle struct {
 	SchemaVersion string                 `json:"schema_version"`
 	GeneratedAt   time.Time              `json:"generated_at"`
-	GeneratedBy   string                 `json:"generated_by,omitempty"`
 	Redaction     DebugBundleRedaction   `json:"redaction"`
 	Server        DebugBundleServer      `json:"server"`
 	Config        DebugBundleConfig      `json:"config"`
@@ -66,14 +64,14 @@ type DebugBundleRuntime struct {
 }
 
 type DebugBundleSyncHealth struct {
-	Status             string                     `json:"status"`
-	EvaluatedAt         time.Time                  `json:"evaluated_at"`
-	Reasons             []DebugBundleReason        `json:"reasons"`
-	GreenSyncCompleted bool                       `json:"green_sync_completed"`
-	GreenSyncState     string                     `json:"green_sync_state"`
-	OperationCounts    SyncOperationCounts         `json:"operation_counts"`
-	Latency            SyncLatency                 `json:"latency_ms"`
-	Clients            []SyncClientSummary         `json:"clients"`
+	Status             string              `json:"status"`
+	EvaluatedAt         time.Time           `json:"evaluated_at"`
+	Reasons             []DebugBundleReason `json:"reasons"`
+	GreenSyncCompleted bool                `json:"green_sync_completed"`
+	GreenSyncState     string              `json:"green_sync_state"`
+	OperationCounts    SyncOperationCounts  `json:"operation_counts"`
+	Latency            SyncLatency          `json:"latency_ms"`
+	Clients            []SyncClientSummary  `json:"clients"`
 }
 
 type DebugBundleReason struct {
@@ -133,7 +131,6 @@ func (s *DebugBundleService) Build(ctx context.Context) (*DebugBundle, error) {
 	bundle := &DebugBundle{
 		SchemaVersion: DebugBundleSchemaVersion,
 		GeneratedAt:   time.Now().UTC(),
-		GeneratedBy:   s.options.GeneratedBy,
 		Redaction: DebugBundleRedaction{
 			Mode:                 "default",
 			RawICSIncluded:       false,

--- a/server/internal/services/debug_bundle_test.go
+++ b/server/internal/services/debug_bundle_test.go
@@ -27,6 +27,7 @@ func (f fakeDebugOperationLister) ListRecent(ctx context.Context, limit int) ([]
 }
 
 func TestDebugBundleBuildsRedactedDiagnostics(t *testing.T) {
+	t.Setenv("CALENDARAPP_USER", "private-admin-user")
 	t.Setenv("CALENDARAPP_PASS", "super-secret-password")
 	t.Setenv("TODOIST_TOKEN", "todoist-secret-token")
 	t.Setenv("OPENAI_API_KEY", "llm-secret-key")
@@ -38,6 +39,8 @@ func TestDebugBundleBuildsRedactedDiagnostics(t *testing.T) {
 		"attendee@example.com",
 		"private-event-1",
 		"testuser",
+		"private-admin-user",
+		"local-principal",
 		"default",
 		"PrivateDeviceName",
 		"SecretBuildToken",
@@ -62,7 +65,7 @@ func TestDebugBundleBuildsRedactedDiagnostics(t *testing.T) {
 	}}
 	service := NewDebugBundleService(
 		NewSyncHealthService(fakeDebugOperationLister{operations: ops}, UnknownGreenSyncProvider()),
-		DebugBundleOptions{Version: "test", Environment: "development", DataDir: "/private/data", MigrationsDir: "/private/migrations", GeneratedBy: "testuser"},
+		DebugBundleOptions{Version: "test", Environment: "development", DataDir: "/private/data", MigrationsDir: "/private/migrations"},
 	)
 
 	bundle, err := service.Build(context.Background())
@@ -93,6 +96,9 @@ func TestDebugBundleBuildsRedactedDiagnostics(t *testing.T) {
 		t.Fatalf("marshal bundle: %v", err)
 	}
 	body := string(payload)
+	if strings.Contains(body, "generated_by") {
+		t.Fatalf("debug bundle should not include generated_by: %s", body)
+	}
 	for _, fragment := range privateFragments {
 		if strings.Contains(body, fragment) {
 			t.Fatalf("debug bundle leaked private fragment %q in %s", fragment, body)

--- a/server/internal/services/debug_bundle_test.go
+++ b/server/internal/services/debug_bundle_test.go
@@ -116,3 +116,9 @@ func TestDebugBundleBuildReturnsServiceError(t *testing.T) {
 		t.Fatal("Build() error = nil, want error")
 	}
 }
+
+func TestDebugBundleSchemaVersion(t *testing.T) {
+	if DebugBundleSchemaVersion != "debug_bundle.v1" {
+		t.Fatalf("DebugBundleSchemaVersion = %q", DebugBundleSchemaVersion)
+	}
+}

--- a/server/internal/services/debug_bundle_test.go
+++ b/server/internal/services/debug_bundle_test.go
@@ -1,0 +1,118 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/airplne/calendar-app/server/internal/domain"
+)
+
+type fakeDebugOperationLister struct {
+	operations []*domain.CalDAVOperation
+	err        error
+}
+
+func (f fakeDebugOperationLister) ListRecent(ctx context.Context, limit int) ([]*domain.CalDAVOperation, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	if limit > 0 && len(f.operations) > limit {
+		return f.operations[:limit], nil
+	}
+	return f.operations, nil
+}
+
+func TestDebugBundleBuildsRedactedDiagnostics(t *testing.T) {
+	t.Setenv("CALENDARAPP_PASS", "super-secret-password")
+	t.Setenv("TODOIST_TOKEN", "todoist-secret-token")
+	t.Setenv("OPENAI_API_KEY", "llm-secret-key")
+
+	privateFragments := []string{
+		"BEGIN:VCALENDAR",
+		"Sensitive Doctor Appointment",
+		"Detailed private description",
+		"attendee@example.com",
+		"private-event-1",
+		"testuser",
+		"default",
+		"PrivateDeviceName",
+		"SecretBuildToken",
+		"super-secret-password",
+		"todoist-secret-token",
+		"llm-secret-key",
+	}
+
+	now := time.Now().UTC()
+	ops := []*domain.CalDAVOperation{{
+		OccurredAt:        now,
+		Method:            "PUT",
+		PathPattern:       "/dav/calendars/{principal}/{calendar}/{object}.ics",
+		StatusCode:        412,
+		DurationMillis:    17,
+		ClientFingerprint: domain.CalDAVClientFantastical,
+		ETagOutcome:       domain.CalDAVETagMismatched,
+		OperationKind:     domain.CalDAVOperationWrite,
+		Outcome:           domain.CalDAVOperationRecoverableFailure,
+		ErrorCode:         domain.CalDAVErrorETagConflict,
+		RedactedError:     "ETag precondition failed.",
+	}}
+	service := NewDebugBundleService(
+		NewSyncHealthService(fakeDebugOperationLister{operations: ops}, UnknownGreenSyncProvider()),
+		DebugBundleOptions{Version: "test", Environment: "development", DataDir: "/private/data", MigrationsDir: "/private/migrations", GeneratedBy: "testuser"},
+	)
+
+	bundle, err := service.Build(context.Background())
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if bundle.SchemaVersion != DebugBundleSchemaVersion {
+		t.Fatalf("SchemaVersion = %q, want %q", bundle.SchemaVersion, DebugBundleSchemaVersion)
+	}
+	if bundle.Redaction.RawICSIncluded || bundle.Redaction.RawUserAgentIncluded || bundle.Redaction.SecretsIncluded {
+		t.Fatalf("unexpected raw-data flags: %+v", bundle.Redaction)
+	}
+	if bundle.SyncHealth.Status != string(domain.SyncHealthUnknown) {
+		t.Fatalf("sync status = %q, want unknown", bundle.SyncHealth.Status)
+	}
+	if len(bundle.CalDAV.RecentOperations) != 1 {
+		t.Fatalf("recent operations = %d, want 1", len(bundle.CalDAV.RecentOperations))
+	}
+	if bundle.CalDAV.RecentOperations[0].ClientFingerprint != domain.CalDAVClientFantastical {
+		t.Fatalf("client fingerprint = %q", bundle.CalDAV.RecentOperations[0].ClientFingerprint)
+	}
+	if len(bundle.ErrorTraces) != 1 || bundle.ErrorTraces[0].ErrorCode != string(domain.CalDAVErrorETagConflict) {
+		t.Fatalf("error traces = %+v", bundle.ErrorTraces)
+	}
+
+	payload, err := json.Marshal(bundle)
+	if err != nil {
+		t.Fatalf("marshal bundle: %v", err)
+	}
+	body := string(payload)
+	for _, fragment := range privateFragments {
+		if strings.Contains(body, fragment) {
+			t.Fatalf("debug bundle leaked private fragment %q in %s", fragment, body)
+		}
+	}
+	for _, secretName := range []string{"CALENDARAPP_PASS", "TODOIST_TOKEN", "OPENAI_API_KEY"} {
+		if !strings.Contains(body, secretName) {
+			t.Fatalf("debug bundle should include redacted secret name %q for diagnostics: %s", secretName, body)
+		}
+	}
+}
+
+func TestDebugBundleBuildReturnsServiceError(t *testing.T) {
+	service := NewDebugBundleService(
+		NewSyncHealthService(fakeDebugOperationLister{err: errors.New("database contains private-event-1")}, UnknownGreenSyncProvider()),
+		DebugBundleOptions{},
+	)
+
+	_, err := service.Build(context.Background())
+	if err == nil {
+		t.Fatal("Build() error = nil, want error")
+	}
+}


### PR DESCRIPTION
## Summary

Implements issue #14 by adding a redacted debug bundle export for CalDAV Sync Health diagnostics.

Closes #14.

## Scope

- Adds debug bundle service/API.
- Includes Sync Health status and reasons.
- Includes redacted recent CalDAV operation metadata.
- Includes normalized client summaries.
- Excludes raw ICS, raw user-agent, event content, task content, LLM context, Todoist data, and secrets by default.
- Reuses existing Basic Auth/env credentials as the MVP authenticated local admin guard.
- Adds redaction and access-control tests.

## Auth decision

The repo currently has Basic Auth/env credentials as the only auth/session model. This PR protects `GET /api/v1/debug-bundle` with the existing Basic Auth middleware instead of exposing a public endpoint. A richer local admin/session model can replace this later.

## Non-goals

- Does not implement onboarding green-sync validation.
- Does not implement frontend dashboard.
- Does not add LLM or Todoist behavior.
- Does not add planning/apply behavior.
- Does not add app-specific CalDAV passwords.
- Does not add raw-data opt-in export.

## Tests

- [ ] `cd server && go test ./...`
